### PR TITLE
Refactor Execution Logic Into Separate Command

### DIFF
--- a/.changeset/nice-cougars-impress.md
+++ b/.changeset/nice-cougars-impress.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/plugins': patch
+---
+
+Refactor execution into separate CLI command

--- a/packages/plugins/src/hardhat/tasks.ts
+++ b/packages/plugins/src/hardhat/tasks.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import * as fs from 'fs'
 
-import { ethers } from 'ethers'
+import { Contract, ethers } from 'ethers'
 import { subtask, task, types } from 'hardhat/config'
 import { SolcBuild } from 'hardhat/types'
 import {
@@ -27,8 +27,18 @@ import {
   registerChugSplashProject,
   getChugSplashRegistry,
   parseChugSplashConfig,
+  isSetImplementationAction,
+  fromRawChugSplashAction,
+  getProxyAddress,
+  createDeploymentFolderForNetwork,
+  writeDeploymentArtifact,
+  log as ChugSplashLog,
 } from '@chugsplash/core'
-import { ChugSplashManagerABI } from '@chugsplash/contracts'
+import {
+  ChugSplashManagerABI,
+  EXECUTOR_BOND_AMOUNT,
+  ProxyABI,
+} from '@chugsplash/contracts'
 import ora from 'ora'
 import { SingleBar, Presets } from 'cli-progress'
 import Hash from 'ipfs-only-hash'
@@ -36,6 +46,9 @@ import * as dotenv from 'dotenv'
 
 import {
   generateRuntimeBytecode,
+  getBuildInfo,
+  getConstructorArgValues,
+  getContractArtifact,
   getImmutableVariables,
   getStorageLayout,
 } from './artifacts'
@@ -60,6 +73,7 @@ const TASK_CHUGSPLASH_CHECK_BUNDLE = 'chugsplash-check-bundle'
 const TASK_CHUGSPLASH_COMMIT = 'chugsplash-commit'
 const TASK_CHUGSPLASH_PROPOSE = 'chugsplash-propose'
 const TASK_CHUGSPLASH_APPROVE = 'chugsplash-approve'
+const TASK_CHUGSPLASH_EXECUTE = 'chugsplash-execute'
 const TASK_CHUGSPLASH_LIST_BUNDLES = 'chugsplash-list-bundles'
 const TASK_CHUGSPLASH_STATUS = 'chugsplash-status'
 
@@ -377,6 +391,196 @@ task(TASK_CHUGSPLASH_PROPOSE)
         spinner.fail('Bundle is currently active.')
       }
       return { bundle, configUri, bundleId }
+    }
+  )
+
+task(TASK_CHUGSPLASH_EXECUTE)
+  .setDescription('Executes an approved bundle.')
+  .addParam('chugSplashManager', 'ChugSplashManager Contract')
+  .addParam('bundleState', 'State of the bundle to be executed')
+  .addParam('bundle', 'The bundle to be executed')
+  .addParam('deployerAddress', 'Address of the user deploying the bundle')
+  .addParam('parsedConfig', 'Parsed ChugSplash configuration')
+  .addParam('deployer', 'Deploying signer')
+  .addFlag('hide', 'Whether to hide logging or not')
+  .setAction(
+    async (
+      args: {
+        chugSplashManager: Contract
+        bundleState: ChugSplashBundleState
+        bundle: any // todo - figure out a type for this
+        deployerAddress: any // todo - figure out a type for this
+        parsedConfig: ChugSplashConfig
+        deployer: any // todo - figure out a type for this
+        hide: boolean
+      },
+      hre: any
+    ) => {
+      const {
+        chugSplashManager,
+        bundleState,
+        bundle,
+        deployerAddress,
+        parsedConfig,
+        deployer,
+        hide,
+      } = args
+
+      if (bundleState.selectedExecutor === ethers.constants.AddressZero) {
+        const tx = await chugSplashManager.claimBundle({
+          value: EXECUTOR_BOND_AMOUNT,
+        })
+        await tx.wait()
+      }
+
+      // Execute the SetCode and DeployImplementation actions that have not been executed yet. Note that
+      // the SetImplementation actions have already been sorted so that they are at the end of the
+      // actions array.
+      const firstSetImplementationActionIndex = bundle.actions.findIndex(
+        (action) =>
+          isSetImplementationAction(fromRawChugSplashAction(action.action))
+      )
+      for (
+        let i = bundleState.actionsExecuted;
+        i < firstSetImplementationActionIndex;
+        i++
+      ) {
+        const action = bundle.actions[i]
+        const tx = await chugSplashManager.executeChugSplashAction(
+          action.action,
+          action.proof.actionIndex,
+          action.proof.siblings
+        )
+        await tx.wait()
+      }
+
+      // If the bundle hasn't already been completed in an earlier call, complete the bundle by
+      // executing all the SetImplementation actions in a single transaction.
+      let finalDeploymentTxnHash: string
+      let finalDeploymentReceipt: any
+      if (bundleState.status !== ChugSplashBundleStatus.COMPLETED) {
+        const setImplActions = bundle.actions.slice(
+          firstSetImplementationActionIndex
+        )
+        const finalDeploymentTxn =
+          await chugSplashManager.completeChugSplashBundle(
+            setImplActions.map((action) => action.action),
+            setImplActions.map((action) => action.proof.actionIndex),
+            setImplActions.map((action) => action.proof.siblings)
+          )
+        finalDeploymentReceipt = await finalDeploymentTxn.wait()
+        finalDeploymentTxnHash = finalDeploymentTxn.hash
+      }
+
+      // Withdraw all available funds from the ChugSplashManager.
+      const totalDebt = await chugSplashManager.totalDebt()
+      const chugsplashManagerBalance = await hre.ethers.provider.getBalance(
+        chugSplashManager.address
+      )
+      if (chugsplashManagerBalance.sub(totalDebt).gt(0)) {
+        await (await chugSplashManager.withdrawOwnerETH()).wait()
+      }
+      const deployerDebt = await chugSplashManager.debt(deployerAddress)
+      if (deployerDebt.gt(0)) {
+        await (await chugSplashManager.claimExecutorPayment()).wait()
+      }
+
+      // Transfer ownership of the deployments to the project owner.
+      for (const referenceName of Object.keys(parsedConfig.contracts)) {
+        // First, check if the Proxy's owner is the ChugSplashManager by getting the latest
+        // `AdminChanged` event on the Proxy.
+        const Proxy = new ethers.Contract(
+          getProxyAddress(parsedConfig.options.projectName, referenceName),
+          new ethers.utils.Interface(ProxyABI),
+          deployer
+        )
+        const { args: queryArgs } = (
+          await Proxy.queryFilter('AdminChanged')
+        ).at(-1)
+        if (queryArgs.newAdmin === chugSplashManager.address) {
+          await (
+            await chugSplashManager.transferProxyOwnership(
+              referenceName,
+              parsedConfig.options.projectOwner
+            )
+          ).wait()
+        }
+      }
+
+      if (
+        parsedConfig.options.projectOwner !== (await chugSplashManager.owner())
+      ) {
+        if (
+          parsedConfig.options.projectOwner === ethers.constants.AddressZero
+        ) {
+          await (await chugSplashManager.renounceOwnership()).wait()
+        } else {
+          await (
+            await chugSplashManager.transferOwnership(
+              parsedConfig.options.projectOwner
+            )
+          ).wait()
+        }
+      }
+
+      if (!hide) {
+        const deployments = {}
+        Object.entries(parsedConfig.contracts).forEach(
+          ([referenceName, contractConfig], i) =>
+            (deployments[i + 1] = {
+              Reference: referenceName,
+              Contract: contractConfig.contract,
+              Address: contractConfig.address,
+            })
+        )
+        console.table(deployments)
+      }
+
+      if ((await getChainId(hre.ethers.provider)) !== 31337) {
+        createDeploymentFolderForNetwork(
+          hre.network.name,
+          hre.config.paths.deployed
+        )
+
+        for (const [referenceName, contractConfig] of Object.entries(
+          parsedConfig.contracts
+        )) {
+          const { sourceName, contractName, bytecode, abi } =
+            getContractArtifact(contractConfig.contract)
+
+          const buildInfo = await getBuildInfo(sourceName, contractName)
+          const metadata =
+            buildInfo.output.contracts[sourceName][contractName].metadata
+          const { devdoc, userdoc } = JSON.parse(metadata).output
+          const artifact = {
+            contractName,
+            address: contractConfig.address,
+            abi,
+            transactionHash: finalDeploymentTxnHash,
+            solcInputHash: buildInfo.id,
+            receipt: finalDeploymentReceipt,
+            numDeployments: 1,
+            metadata,
+            args: await getConstructorArgValues(contractConfig),
+            bytecode,
+            deployedBytecode: await hre.ethers.provider.getCode(
+              contractConfig.address
+            ),
+            devdoc,
+            userdoc,
+            storageLayout: await getStorageLayout(contractConfig.contract),
+          }
+
+          writeDeploymentArtifact(
+            hre.network.name,
+            hre.config.paths.deployed,
+            artifact,
+            referenceName
+          )
+        }
+      }
+
+      ChugSplashLog(`Deployed: ${parsedConfig.options.projectName}`, hide)
     }
   )
 


### PR DESCRIPTION
Moves the logic for executing a bundle into a separate CLI command so that it can be used by the executor. 