### PR TITLE
Fix: chugsplash-execute incorrect typing

### DIFF
--- a/.changeset/lemon-wolves-sing.md
+++ b/.changeset/lemon-wolves-sing.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/plugins': patch
+---
+
+Resolve type issues with chugsplash-execute command

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -142,7 +142,7 @@ export const deployChugSplashConfig = async (
 
   // todo call chugsplash-execute if deploying locally
   await hre.run('chugsplash-execute', {
-    ChugSplashManager,
+    chugSplashManager: ChugSplashManager,
     bundleState,
     bundle,
     deployerAddress,

--- a/packages/plugins/src/hardhat/tasks.ts
+++ b/packages/plugins/src/hardhat/tasks.ts
@@ -390,14 +390,29 @@ task(TASK_CHUGSPLASH_PROPOSE)
     }
   )
 
-task(TASK_CHUGSPLASH_EXECUTE)
+subtask(TASK_CHUGSPLASH_EXECUTE)
   .setDescription('Executes an approved bundle.')
-  .addParam('chugSplashManager', 'ChugSplashManager Contract')
-  .addParam('bundleState', 'State of the bundle to be executed')
-  .addParam('bundle', 'The bundle to be executed')
+  .addParam(
+    'chugSplashManager',
+    'ChugSplashManager Contract',
+    undefined,
+    types.any
+  )
+  .addParam(
+    'bundleState',
+    'State of the bundle to be executed',
+    undefined,
+    types.any
+  )
+  .addParam('bundle', 'The bundle to be executed', undefined, types.any)
   .addParam('deployerAddress', 'Address of the user deploying the bundle')
-  .addParam('parsedConfig', 'Parsed ChugSplash configuration')
-  .addParam('deployer', 'Deploying signer')
+  .addParam(
+    'parsedConfig',
+    'Parsed ChugSplash configuration',
+    undefined,
+    types.any
+  )
+  .addParam('deployer', 'Deploying signer', undefined, types.any)
   .addFlag('hide', 'Whether to hide logging or not')
   .setAction(
     async (


### PR DESCRIPTION
- Fixes an issue where `chugsplash-execute` was called incorrectly. 
- Fixes an issue where the types for `chugsplash-execute` were not properly defined (Note, I just set them to any to make sure it works for now. Would be good to improve this in the future).