### PR TITLE
fix: integrate etherscan verification into executor

### DIFF
--- a/.changeset/good-maps-run.md
+++ b/.changeset/good-maps-run.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/plugins': patch
+---
+
+Refactor remote bundling logic

--- a/.changeset/honest-shrimps-bake.md
+++ b/.changeset/honest-shrimps-bake.md
@@ -1,0 +1,6 @@
+---
+'@chugsplash/executor': patch
+'@chugsplash/plugins': patch
+---
+
+Integrate etherscan verification into executor

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -7,7 +7,6 @@ import {
   ChugSplashRegistryABI,
   ChugSplashManagerABI,
   ChugSplashManagerProxyArtifact,
-  // CHUGSPLASH_REGISTRY_ADDRESS,
   CHUGSPLASH_REGISTRY_PROXY_ADDRESS,
 } from '@chugsplash/contracts'
 
@@ -69,14 +68,14 @@ export const writeDeploymentArtifact = (
 
 export const getProxyAddress = (
   projectName: string,
-  target: string
+  referenceName: string
 ): string => {
   // const chugSplashManagerAddress = getChugSplashManagerAddress(projectName)
   const chugSplashManagerAddress = getChugSplashManagerProxyAddress(projectName)
 
   return utils.getCreate2Address(
     chugSplashManagerAddress,
-    utils.keccak256(utils.toUtf8Bytes(target)),
+    utils.keccak256(utils.toUtf8Bytes(referenceName)),
     utils.solidityKeccak256(
       ['bytes', 'bytes'],
       [

--- a/packages/executor/.gitignore
+++ b/packages/executor/.gitignore
@@ -1,2 +1,3 @@
 dist/
 .env
+cache

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -7,8 +7,9 @@ import {
   CHUGSPLASH_REGISTRY_PROXY_ADDRESS,
 } from '@chugsplash/contracts'
 import { ChugSplashBundleState } from '@chugsplash/core'
+import { getChainId } from '@eth-optimism/core-utils'
 
-import { compileRemoteBundle } from './utils'
+import { compileRemoteBundle, verifyChugSplashConfig } from './utils'
 
 type Options = {
   network: string
@@ -116,6 +117,10 @@ export class ChugSplashExecutor extends BaseServiceV2<Options, Metrics, State> {
         deployer: signer,
         hide: false,
       })
+
+      if ((await getChainId(this.state.wallet.provider)) !== 31337) {
+        await verifyChugSplashConfig(hre, proposalEvent.args.configUri)
+      }
     }
   }
 }

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -112,7 +112,6 @@ export class ChugSplashExecutor extends BaseServiceV2<Options, Metrics, State> {
         chugSplashManager: manager,
         bundleState,
         bundle,
-        deployerAddress: await signer.getAddress(),
         parsedConfig: canonicalConfig,
         deployer: signer,
         hide: false,

--- a/packages/executor/src/utils/compile.ts
+++ b/packages/executor/src/utils/compile.ts
@@ -32,7 +32,7 @@ export const compileRemoteBundle = async (
 }> => {
   const canonicalConfig = await fetchChugSplashConfig(configUri)
   const bundle = await hre.run('chugsplash-bundle-remote', {
-    deployConfig: canonicalConfig,
+    canonicalConfig,
   })
   return { bundle, canonicalConfig }
 }

--- a/packages/executor/src/utils/compile.ts
+++ b/packages/executor/src/utils/compile.ts
@@ -1,17 +1,12 @@
 import * as dotenv from 'dotenv'
-import { SolcBuild } from 'hardhat/types'
-import {
-  TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD,
-  TASK_COMPILE_SOLIDITY_RUN_SOLCJS,
-  TASK_COMPILE_SOLIDITY_RUN_SOLC,
-} from 'hardhat/builtin-tasks/task-names'
-import { add0x } from '@eth-optimism/core-utils'
 import {
   CanonicalChugSplashConfig,
   ChugSplashActionBundle,
 } from '@chugsplash/core'
-import { create } from 'ipfs-http-client'
-import { ContractArtifact } from '@chugsplash/plugins'
+import {
+  TASK_CHUGSPLASH_FETCH,
+  TASK_CHUGSPLASH_BUNDLE_REMOTE,
+} from '@chugsplash/plugins'
 
 // Load environment variables from .env
 dotenv.config()
@@ -30,89 +25,11 @@ export const compileRemoteBundle = async (
   bundle: ChugSplashActionBundle
   canonicalConfig: CanonicalChugSplashConfig
 }> => {
-  const canonicalConfig = await fetchChugSplashConfig(configUri)
-  const bundle = await hre.run('chugsplash-bundle-remote', {
+  const canonicalConfig = await hre.run(TASK_CHUGSPLASH_FETCH, {
+    configUri,
+  })
+  const bundle = await hre.run(TASK_CHUGSPLASH_BUNDLE_REMOTE, {
     canonicalConfig,
   })
   return { bundle, canonicalConfig }
-}
-
-export const getArtifactsFromCanonicalConfig = async (
-  hre: any,
-  canonicalConfig: CanonicalChugSplashConfig
-): Promise<{
-  [contractName: string]: ContractArtifact
-}> => {
-  const artifacts = {}
-  for (const source of canonicalConfig.inputs) {
-    const solcBuild: SolcBuild = await hre.run(
-      TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD,
-      {
-        quiet: true,
-        solcVersion: source.solcVersion,
-      }
-    )
-
-    let output: any // TODO: Compiler output
-    if (solcBuild.isSolcJs) {
-      output = await hre.run(TASK_COMPILE_SOLIDITY_RUN_SOLCJS, {
-        input: source.input,
-        solcJsPath: solcBuild.compilerPath,
-      })
-    } else {
-      output = await hre.run(TASK_COMPILE_SOLIDITY_RUN_SOLC, {
-        input: source.input,
-        solcPath: solcBuild.compilerPath,
-      })
-    }
-
-    for (const [sourceName, fileOutput] of Object.entries(output.contracts)) {
-      for (const [contractName, contractOutput] of Object.entries(fileOutput)) {
-        artifacts[contractName] = {
-          bytecode: add0x(contractOutput.evm.bytecode.object),
-          storageLayout: contractOutput.storageLayout,
-          contractName,
-          sourceName,
-          abi: contractOutput.abi,
-          sources: output.sources,
-          immutableReferences:
-            output.contracts[sourceName][contractName].evm.deployedBytecode
-              .immutableReferences,
-        }
-      }
-    }
-  }
-  return artifacts
-}
-
-// TODO: change file name or add another file
-export const fetchChugSplashConfig = async (
-  configUri: string
-): Promise<CanonicalChugSplashConfig> => {
-  const projectCredentials = `${process.env.IPFS_PROJECT_ID}:${process.env.IPFS_API_KEY_SECRET}`
-  const ipfs = create({
-    host: 'ipfs.infura.io',
-    port: 5001,
-    protocol: 'https',
-    headers: {
-      authorization: `Basic ${Buffer.from(projectCredentials).toString(
-        'base64'
-      )}`,
-    },
-  })
-
-  let config: CanonicalChugSplashConfig
-  if (configUri.startsWith('ipfs://')) {
-    const decoder = new TextDecoder()
-    let data = ''
-    const stream = await ipfs.cat(configUri.replace('ipfs://', ''))
-    for await (const chunk of stream) {
-      // Chunks of data are returned as a Uint8Array. Convert it back to a string
-      data += decoder.decode(chunk, { stream: true })
-    }
-    config = JSON.parse(data)
-  } else {
-    throw new Error('unsupported URI type')
-  }
-  return config
 }

--- a/packages/executor/src/utils/etherscan.ts
+++ b/packages/executor/src/utils/etherscan.ts
@@ -57,14 +57,14 @@ export const verifyChugSplashConfig = async (hre: any, configUri: string) => {
     canonicalConfig.contracts
   )) {
     const artifact = artifacts[contractConfig.contract]
-    const { abi, contractName, sourceName, sources, immutableReferences } =
-      artifact
-    const { constructorArgValues } = await getConstructorArgs(
+    const { abi, contractName, sourceName, fileOutput } = artifact
+    const { constructorArgValues } = getConstructorArgs(
       canonicalConfig,
       referenceName,
       abi,
-      sources,
-      immutableReferences
+      fileOutput,
+      sourceName,
+      contractName
     )
 
     const contractAddress = await ChugSplashManager.implementations(

--- a/packages/executor/src/utils/initialize.ts
+++ b/packages/executor/src/utils/initialize.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers'
-import { deployChugSplashContracts } from '@chugsplash/plugins'
+import { deployChugSplashPredeploys } from '@chugsplash/plugins'
 import {
   CHUGSPLASH_CONSTRUCTOR_ARGS,
   ChugSplashBootLoaderArtifact,
@@ -29,7 +29,7 @@ export const initializeChugSplashContracts = async (
   hre: any,
   deployer: ethers.Signer
 ) => {
-  await deployChugSplashContracts(hre, deployer)
+  await deployChugSplashPredeploys(hre, deployer)
 
   const { etherscanApiKey, etherscanApiEndpoints } = await getEtherscanInfo(hre)
 

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -77,7 +77,7 @@ export const deployChugSplashConfig = async (
 
   const { bundleId } = await hre.run('chugsplash-commit', {
     deployConfig: configRelativePath,
-    local: false,
+    local,
     log: verbose,
   })
 
@@ -113,7 +113,7 @@ export const deployChugSplashConfig = async (
 
   const { bundle } = await hre.run('chugsplash-propose', {
     deployConfig: configRelativePath,
-    local: false,
+    local,
     log: verbose,
   })
 
@@ -148,7 +148,6 @@ export const deployChugSplashConfig = async (
       chugSplashManager: ChugSplashManager,
       bundleState,
       bundle,
-      deployerAddress,
       parsedConfig,
       deployer,
       hide,

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -28,7 +28,7 @@ import { writeHardhatSnapshotId } from './utils'
  * @param hre Hardhat Runtime Environment.
  * @param contractName Name of the contract in the config file.
  */
-export const deployContracts = async (
+export const deployConfigs = async (
   hre: any,
   verbose: boolean,
   hide: boolean,
@@ -36,11 +36,11 @@ export const deployContracts = async (
 ) => {
   const fileNames = fs.readdirSync(hre.config.paths.chugsplash)
   for (const fileName of fileNames) {
-    await deployChugSplashConfig(hre, fileName, verbose, hide, local)
+    await deployConfig(hre, fileName, verbose, hide, local)
   }
 }
 
-export const deployChugSplashConfig = async (
+export const deployConfig = async (
   hre: any,
   fileName: string,
   verbose: boolean,

--- a/packages/plugins/src/hardhat/predeploys.ts
+++ b/packages/plugins/src/hardhat/predeploys.ts
@@ -21,7 +21,7 @@ import {
   CHUGSPLASH_CONSTRUCTOR_ARGS,
 } from '@chugsplash/contracts'
 
-export const deployChugSplashContracts = async (
+export const deployChugSplashPredeploys = async (
   hre: HardhatRuntimeEnvironment,
   deployer: ethers.Signer
 ): Promise<void> => {


### PR DESCRIPTION
This PR:
* Fixes a bug with the remote bundling logic
* Refactors redundant remote bundling and fetching logic
* Integrates Etherscan verification into the executor