### PR TITLE
Remove --local parameter

### DIFF
--- a/.changeset/plenty-tigers-confess.md
+++ b/.changeset/plenty-tigers-confess.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/plugins': patch
+---
+
+Remove local flag

--- a/packages/executor/.env.example
+++ b/packages/executor/.env.example
@@ -6,3 +6,4 @@ IPFS_API_KEY_SECRET=<ipfs api key to retrieve config file>
 OPT_ETHERSCAN_API_KEY=<Optimism Etherscan API key>
 ETH_ETHERSCAN_API_KEY=<Ethereum Etherscan API key>
 INFURA_API_KEY=<Infura Project API Key>
+HARDHAT_NETWORK=<Target hardhat network, used for verification>

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -29,11 +29,8 @@ import { writeHardhatSnapshotId } from './utils'
  * @param hre Hardhat Runtime Environment.
  * @param contractName Name of the contract in the config file.
  */
-export const deployConfigs = async (
-  hre: any,
-  silent: boolean,
-  local: boolean
-) => {
+export const deployConfigs = async (hre: any, silent: boolean) => {
+  const local = (await getChainId(hre.ethers.provider)) === 31337 ? true : false
   const fileNames = fs.readdirSync(hre.config.paths.chugsplash)
   for (const fileName of fileNames) {
     await deployConfig(hre, fileName, silent, local)

--- a/packages/plugins/src/hardhat/tasks.ts
+++ b/packages/plugins/src/hardhat/tasks.ts
@@ -212,23 +212,16 @@ subtask(TASK_CHUGSPLASH_FETCH)
 
 task(TASK_CHUGSPLASH_DEPLOY)
   .addFlag('silent', "Hide all of ChugSplash's output")
-  .addOptionalParam<boolean>(
-    'local',
-    'Enable local execution within the CLI',
-    true,
-    types.boolean
-  )
   .setAction(
     async (
       args: {
         silent: boolean
-        local: boolean
       },
       hre: any
     ) => {
       const signer = await hre.ethers.getSigner()
       await deployChugSplashPredeploys(hre, signer)
-      await deployConfigs(hre, args.silent, args.local)
+      await deployConfigs(hre, args.silent)
     }
   )
 
@@ -1085,19 +1078,12 @@ task(TASK_NODE)
     "Completely disable all of ChugSplash's activity."
   )
   .addFlag('silent', "Hide all of ChugSplash's output")
-  .addOptionalParam<boolean>(
-    'local',
-    'Enable local execution within the CLI',
-    true,
-    types.boolean
-  )
   .setAction(
     async (
       args: {
         setupInternals: boolean
         disableChugsplash: boolean
         silent: boolean
-        local: boolean
       },
       hre: any,
       runSuper
@@ -1106,7 +1092,7 @@ task(TASK_NODE)
         const deployer = await hre.ethers.getSigner()
         await deployChugSplashPredeploys(hre, deployer)
         if (!args.setupInternals) {
-          await deployConfigs(hre, args.silent, args.local)
+          await deployConfigs(hre, args.silent)
         }
         await writeHardhatSnapshotId(hre)
       }
@@ -1116,39 +1102,30 @@ task(TASK_NODE)
 
 task(TASK_TEST)
   .addFlag('show', 'Show ChugSplash deployment information')
-  .addOptionalParam<boolean>(
-    'local',
-    'Enable local execution within the CLI',
-    true,
-    types.boolean
-  )
-  .setAction(
-    async (args: { show: boolean; local: boolean }, hre: any, runSuper) => {
-      if ((await getChainId(hre.ethers.provider)) === 31337) {
-        try {
-          const snapshotIdPath = path.join(
-            path.basename(hre.config.paths.deployed),
-            hre.network.name === 'localhost' ? 'localhost' : 'hardhat',
-            '.snapshotId'
-          )
-          const snapshotId = fs.readFileSync(snapshotIdPath, 'utf8')
-          const snapshotReverted = await hre.network.provider.send(
-            'evm_revert',
-            [snapshotId]
-          )
-          if (!snapshotReverted) {
-            throw new Error('Snapshot failed to be reverted.')
-          }
-        } catch {
-          await deployChugSplashPredeploys(hre, await hre.ethers.getSigner())
-          await deployConfigs(hre, !args.show, args.local)
-        } finally {
-          await writeHardhatSnapshotId(hre)
+  .setAction(async (args: { show: boolean }, hre: any, runSuper) => {
+    if ((await getChainId(hre.ethers.provider)) === 31337) {
+      try {
+        const snapshotIdPath = path.join(
+          path.basename(hre.config.paths.deployed),
+          hre.network.name === 'localhost' ? 'localhost' : 'hardhat',
+          '.snapshotId'
+        )
+        const snapshotId = fs.readFileSync(snapshotIdPath, 'utf8')
+        const snapshotReverted = await hre.network.provider.send('evm_revert', [
+          snapshotId,
+        ])
+        if (!snapshotReverted) {
+          throw new Error('Snapshot failed to be reverted.')
         }
+      } catch {
+        await deployChugSplashPredeploys(hre, await hre.ethers.getSigner())
+        await deployConfigs(hre, !args.show)
+      } finally {
+        await writeHardhatSnapshotId(hre)
       }
-      await runSuper(args)
     }
-  )
+    await runSuper(args)
+  })
 
 task(TASK_RUN).setAction(async (args, hre: any, runSuper) => {
   await hre.run(TASK_CHUGSPLASH_DEPLOY, hre)


### PR DESCRIPTION
## Purpose
- Removes the --local parameter. Instead, the chain id is checked and the execution is done locally if and only if the target network is hardhat. 
- Adds `HARDHAT_NETWORK` to the .env.example file for the executor