### PR TITLE
Parallelize Execution Process

### DIFF
--- a/.changeset/spicy-geese-roll.md
+++ b/.changeset/spicy-geese-roll.md
@@ -1,0 +1,7 @@
+---
+'@chugsplash/demo': patch
+'@chugsplash/executor': patch
+'@chugsplash/plugins': patch
+---
+
+Improve execution speed with parallelization

--- a/packages/demo/hardhat.config.ts
+++ b/packages/demo/hardhat.config.ts
@@ -22,8 +22,18 @@ const config: HardhatUserConfig = {
     },
   },
   networks: {
+    hardhat: {
+      mining: {
+        auto: false,
+        interval: 1000,
+      },
+    },
     localhost: {
       url: 'http://localhost:8545',
+      mining: {
+        auto: false,
+        interval: 1000,
+      },
     },
     goerli: {
       chainId: 5,

--- a/packages/executor/hardhat.config.ts
+++ b/packages/executor/hardhat.config.ts
@@ -17,6 +17,12 @@ const config: HardhatUserConfig = {
     version: '0.8.15',
   },
   networks: {
+    hardhat: {
+      mining: {
+        auto: false,
+        interval: 1000,
+      },
+    },
     'optimism-goerli': {
       chainId: 420,
       url: `https://optimism-goerli.infura.io/v3/${process.env.INFURA_API_KEY}`,

--- a/packages/plugins/dev.ts
+++ b/packages/plugins/dev.ts
@@ -57,7 +57,7 @@ const deployConfigForceCommit = async (fileName: string, silent: boolean) => {
   const { bundleId } = await hre.run('chugsplash-commit', {
     configPath,
     ipfsUrl: '',
-    commitToIpfs: false,
+    commitToIpfs: true,
   })
 
   const ChugSplashManager = new Contract(

--- a/packages/plugins/hardhat.config.ts
+++ b/packages/plugins/hardhat.config.ts
@@ -22,8 +22,18 @@ const config: HardhatUserConfig = {
     },
   },
   networks: {
+    hardhat: {
+      mining: {
+        auto: false,
+        interval: 1000,
+      },
+    },
     localhost: {
       url: 'http://localhost:8545',
+      mining: {
+        auto: false,
+        interval: 1000,
+      },
     },
     goerli: {
       chainId: 5,


### PR DESCRIPTION
## Purpose
Refactors the execution process so that bundle actions are executed in parallel to improve execution speed. 

Note that transaction queuing does not work when automining is enabled on the hardhat network. So if this PR is merged, then all users will be required to use interval mining when testing against the local hardhat network. If it's possible to detect the mining mode of the hardhat network, then we might want to dynamically choose parallel or synchronous execution based on that. This would allow us to support both modes. For the moment though, I think this is a reasonable restriction that we can revisit if/when we encounter a user that cares a lot about using automining. 