### PR TITLE
fix(ex): run the executor using the hre executable

### DIFF
--- a/.changeset/modern-toes-turn.md
+++ b/.changeset/modern-toes-turn.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/executor': patch
+---
+
+Use environment variable `HARDHAT_NETWORK` to determine executor's network

--- a/.changeset/unlucky-wolves-work.md
+++ b/.changeset/unlucky-wolves-work.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/executor': patch
+---
+
+Run the executor using the HRE executable

--- a/packages/executor/.env.example
+++ b/packages/executor/.env.example
@@ -6,4 +6,4 @@ IPFS_API_KEY_SECRET=<ipfs api key to retrieve config file>
 OPT_ETHERSCAN_API_KEY=<Optimism Etherscan API key>
 ETH_ETHERSCAN_API_KEY=<Ethereum Etherscan API key>
 INFURA_API_KEY=<Infura Project API Key>
-NETWORK_NAME=<Target network. Must match a network name in the Hardhat config (e.g. 'optimism-goerli')>
+HARDHAT_NETWORK=<Target hardhat network, used for verification>

--- a/packages/executor/.env.example
+++ b/packages/executor/.env.example
@@ -6,4 +6,4 @@ IPFS_API_KEY_SECRET=<ipfs api key to retrieve config file>
 OPT_ETHERSCAN_API_KEY=<Optimism Etherscan API key>
 ETH_ETHERSCAN_API_KEY=<Ethereum Etherscan API key>
 INFURA_API_KEY=<Infura Project API Key>
-HARDHAT_NETWORK=<Target hardhat network, used for verification>
+NETWORK_NAME=<Target network. Must match a network name in the Hardhat config (e.g. 'optimism-goerli')>

--- a/packages/executor/Dockerfile
+++ b/packages/executor/Dockerfile
@@ -6,4 +6,4 @@ RUN npm install
 
 COPY . .
 
-CMD [ "yarn", "start" ]
+CMD [ "yarn", "start", "--network", "TODO"]

--- a/packages/executor/Dockerfile
+++ b/packages/executor/Dockerfile
@@ -6,4 +6,4 @@ RUN npm install
 
 COPY . .
 
-CMD [ "yarn", "start", "--network", "TODO"]
+CMD [ "yarn", "start" ]

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -8,7 +8,7 @@
     "dist/*"
   ],
   "scripts": {
-    "start": "hardhat run ./src/index.ts",
+    "start": "ts-node ./src/index.ts",
     "build": "yarn build:ts",
     "build:ts": "tsc -p ./tsconfig.json",
     "clean": "rimraf dist/ ./tsconfig.tsbuildinfo",

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -8,7 +8,7 @@
     "dist/*"
   ],
   "scripts": {
-    "start": "ts-node ./src/index.ts",
+    "start": "hardhat run ./src/index.ts",
     "build": "yarn build:ts",
     "build:ts": "tsc -p ./tsconfig.json",
     "clean": "rimraf dist/ ./tsconfig.tsbuildinfo",


### PR DESCRIPTION
This PR fixes the bug that causes Etherscan verification to fail. It does this by changing the executor's executable from ts-node to hardhat, which injects the correct HRE into the environment.