### PR TITLE
Fix: Minor Build Info Parsing Bug

### DIFF
--- a/.changeset/four-drinks-peel.md
+++ b/.changeset/four-drinks-peel.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/plugins': patch
+---
+
+Fix bug parsing build info metadata

--- a/packages/plugins/src/hardhat/artifacts.ts
+++ b/packages/plugins/src/hardhat/artifacts.ts
@@ -414,7 +414,11 @@ export const createDeploymentArtifacts = async (
 
     const metadata =
       buildInfo.output.contracts[sourceName][contractName].metadata
-    const { devdoc, userdoc } = JSON.parse(metadata).output
+
+    const { devdoc, userdoc } =
+      typeof metadata === 'string'
+        ? JSON.parse(metadata).output
+        : metadata.output
 
     const deploymentArtifact = {
       contractName,


### PR DESCRIPTION
## Purpose
Fixes a minor issue where the build info metadata is parsed as if it is JSON when it is not. 