### PR TITLE
fix(pg): update the chugsplash-execute hardhat task

### DIFF
--- a/.changeset/ten-pugs-repair.md
+++ b/.changeset/ten-pugs-repair.md
@@ -1,0 +1,6 @@
+---
+'@chugsplash/core': patch
+'@chugsplash/plugins': patch
+---
+
+Improve chugsplash-deploy hardhat task

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -142,7 +142,7 @@ export const registerChugSplashProject = async (
       projectName
     )
     if (existingProjectOwner !== (await signer.getAddress())) {
-      throw new Error(`Project already registered by: ${existingProjectOwner}.`)
+      throw new Error(`Project already owned by: ${existingProjectOwner}.`)
     } else {
       return false
     }
@@ -169,6 +169,14 @@ export const getChugSplashRegistry = (signer: Signer): Contract => {
     // CHUGSPLASH_REGISTRY_ADDRESS,
     CHUGSPLASH_REGISTRY_PROXY_ADDRESS,
     ChugSplashRegistryABI,
+    signer
+  )
+}
+
+export const getChugSplashManager = (signer: Signer, projectName: string) => {
+  return new Contract(
+    getChugSplashManagerProxyAddress(projectName),
+    ChugSplashManagerABI,
     signer
   )
 }

--- a/packages/plugins/src/hardhat/utils.ts
+++ b/packages/plugins/src/hardhat/utils.ts
@@ -2,6 +2,7 @@ import path from 'path'
 
 import {
   ChugSplashConfig,
+  getChugSplashManagerProxyAddress,
   getChugSplashRegistry,
   parseChugSplashConfig,
   writeSnapshotId,
@@ -52,9 +53,10 @@ export const loadParsedChugSplashConfig = (
 
 export const isProjectRegistered = async (
   signer: Signer,
-  chugsplashManagerAddress: string
+  projectName: string
 ) => {
   const ChugSplashRegistry = getChugSplashRegistry(signer)
+  const chugsplashManagerAddress = getChugSplashManagerProxyAddress(projectName)
   const isRegistered: boolean = await ChugSplashRegistry.managers(
     chugsplashManagerAddress
   )

--- a/packages/plugins/src/messages.ts
+++ b/packages/plugins/src/messages.ts
@@ -25,9 +25,9 @@ export const successfulProposalMessage = (
   networkName: string
 ): string => {
   if (amount.gt(0)) {
-    return `Project successfully proposed on ${networkName}. Next, fund the deployment using the command:
+    return `Project successfully proposed on ${networkName}. Fund and approve the deployment using the command:
 
-  npx hardhat fund --network ${networkName} --amount ${amount} ${configPath}`
+  npx hardhat chugsplash-approve --network ${networkName} --amount ${amount} ${configPath}`
   } else {
     return `Project successfully proposed and funded on ${networkName}. Approve the deployment using the command:
 
@@ -41,9 +41,9 @@ export const alreadyProposedMessage = (
   networkName: string
 ): string => {
   if (amount.gt(0)) {
-    return `Project has already been proposed on ${networkName}. You must fund the deployment using the command:
+    return `Project has already been proposed on ${networkName}. Fund and approve the deployment using the command:
 
-  npx hardhat fund --network ${networkName} --amount ${amount} ${configPath}`
+  npx hardhat chugsplash-approve --network ${networkName} --amount ${amount} ${configPath}`
   } else {
     return `Project has already been proposed and funded on ${networkName}. Approve the deployment using the command:
 


### PR DESCRIPTION
This PR:
* Removes a couple things inside of the execute task that should be user-facing, and puts these into
a function called `postExecutionActions`.
* Changes the execute task's `bundleState` argument to `bundleId` so that the most recent `bundleState` is calculated within the execute task. This fixes a bug I was experiencing where an outdated bundleState was being used in the task
* Improves error handling in the execute task