### PR TITLE
fix(pg): update the chugsplash-execute hardhat task

### DIFF
--- a/.changeset/small-falcons-sort.md
+++ b/.changeset/small-falcons-sort.md
@@ -1,0 +1,6 @@
+---
+'@chugsplash/executor': patch
+'@chugsplash/plugins': patch
+---
+
+Updates the chugsplash-execute task

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -8,7 +8,6 @@ import {
   ChugSplashRegistryABI,
   CHUGSPLASH_REGISTRY_PROXY_ADDRESS,
 } from '@chugsplash/contracts'
-import { ChugSplashBundleState } from '@chugsplash/core'
 import { getChainId } from '@eth-optimism/core-utils'
 import * as Amplitude from '@amplitude/node'
 
@@ -112,11 +111,6 @@ export class ChugSplashExecutor extends BaseServiceV2<Options, Metrics, State> {
         continue
       }
 
-      // fetch bundle state
-      const bundleState: ChugSplashBundleState = await manager.bundles(
-        activeBundleId
-      )
-
       // get proposal event and compile
       const proposalEvents = await manager.queryFilter(
         manager.filters.ChugSplashBundleProposed(activeBundleId)
@@ -141,10 +135,10 @@ export class ChugSplashExecutor extends BaseServiceV2<Options, Metrics, State> {
       try {
         await hre.run('chugsplash-execute', {
           chugSplashManager: manager,
-          bundleState,
+          bundleId: activeBundleId,
           bundle,
           parsedConfig: canonicalConfig,
-          deployer: signer,
+          executor: signer,
           hide: false,
         })
         this.logger.info('Successfully executed')


### PR DESCRIPTION
This PR:
* Removes a couple things inside of the execute task that should be user-facing, and puts these into
a function called `postExecutionActions`.
* Changes the execute task's `bundleState` argument to `bundleId` so that the most recent `bundleState` is calculated within the execute task. This fixes a bug I was experiencing where an outdated bundleState was being used in the task
* Improves error handling in the execute task