### PR TITLE
fix(pg): add noCompile flag to relevant hardhat tasks

### DIFF
--- a/.changeset/wild-rocks-decide.md
+++ b/.changeset/wild-rocks-decide.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/plugins': patch
+---
+
+Add noCompile flag to relevant Hardhat tasks

--- a/packages/contracts/contracts/ChugSplashManager.sol
+++ b/packages/contracts/contracts/ChugSplashManager.sol
@@ -790,11 +790,7 @@ contract ChugSplashManager is OwnableUpgradeable, ReentrancyGuardUpgradeable {
      */
     function _deployImplementation(string memory _target, bytes memory _code) internal {
         // Get the expected address of the implementation contract.
-        address expectedImplementation = Create2.compute(
-            address(this),
-            bytes32(0),
-            _code
-        );
+        address expectedImplementation = Create2.compute(address(this), bytes32(0), _code);
 
         address implementation;
         assembly {

--- a/packages/contracts/src/ifaces.ts
+++ b/packages/contracts/src/ifaces.ts
@@ -7,7 +7,7 @@ export const ProxyUpdaterArtifact = require('../artifacts/contracts/ProxyUpdater
 export const DefaultAdapterArtifact = require('../artifacts/contracts/adapters/DefaultAdapter.sol/DefaultAdapter.json')
 export const ProxyArtifact = require('../artifacts/contracts/libraries/Proxy.sol/Proxy.json')
 
-export const buildInfo = require('../artifacts/build-info/d5ced5690fbead1b00cfc48cc8c48668.json')
+export const buildInfo = require('../artifacts/build-info/8970f8f016e1bfadcb5c3c7e81e74156.json')
 
 export const ChugSplashRegistryABI = ChugSplashRegistryArtifact.abi
 export const ChugSplashBootLoaderABI = ChugSplashBootLoaderArtifact.abi

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -41,7 +41,8 @@ import { postExecutionActions } from './execution'
 export const deployAllChugSplashConfigs = async (
   hre: any,
   silent: boolean,
-  ipfsUrl: string
+  ipfsUrl: string,
+  noCompile: boolean
 ) => {
   const remoteExecution = (await getChainId(hre.ethers.provider)) !== 31337
   const fileNames = fs.readdirSync(hre.config.paths.chugsplash)
@@ -57,7 +58,8 @@ export const deployAllChugSplashConfigs = async (
       configPath,
       silent,
       remoteExecution,
-      ipfsUrl
+      ipfsUrl,
+      noCompile
     )
   }
 }
@@ -67,7 +69,8 @@ export const deployChugSplashConfig = async (
   configPath: string,
   silent: boolean,
   remoteExecution: boolean,
-  ipfsUrl: string
+  ipfsUrl: string,
+  noCompile: boolean
 ) => {
   const provider = hre.ethers.provider
   const signer = provider.getSigner()
@@ -91,7 +94,7 @@ export const deployChugSplashConfig = async (
       parsedConfig,
       ipfsUrl,
       commitToIpfs: false,
-      compile: true,
+      noCompile,
     },
     hre
   )
@@ -315,7 +318,7 @@ export const proposeChugSplashBundle = async (
         parsedConfig,
         ipfsUrl,
         commitToIpfs: true,
-        compile: false,
+        noCompile: true,
       },
       hre
     )


### PR DESCRIPTION
Adds a `--no-compile` flag to the `node`, `test`, `run`, `chugsplash-deploy`, `test-remote-execution`, and `chugsplash-propose` task. Speeds up deployments significantly in larger repos.