### PR TITLE
fix(ex): wrap Etherscan verification attempts in try/catch blocks

### DIFF
--- a/.changeset/calm-students-type.md
+++ b/.changeset/calm-students-type.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/executor': patch
+---
+
+Wrap Etherscan verification attempts in try/catch blocks

--- a/packages/executor/src/utils/etherscan.ts
+++ b/packages/executor/src/utils/etherscan.ts
@@ -69,13 +69,17 @@ export const verifyChugSplashConfig = async (
   const chugsplashManagerProxyAddress = getChugSplashManagerProxyAddress(
     canonicalConfig.options.projectName
   )
-  await linkProxyWithImplementation(
-    etherscanApiEndpoints,
-    etherscanApiKey,
-    chugsplashManagerProxyAddress,
-    CHUGSPLASH_MANAGER_ADDRESS,
-    'ChugSplashManager'
-  )
+  try {
+    await linkProxyWithImplementation(
+      etherscanApiEndpoints,
+      etherscanApiKey,
+      chugsplashManagerProxyAddress,
+      CHUGSPLASH_MANAGER_ADDRESS,
+      'ChugSplashManager'
+    )
+  } catch (err) {
+    console.error(err)
+  }
 
   for (const referenceName of Object.keys(canonicalConfig.contracts)) {
     const artifact = artifacts[referenceName]
@@ -102,27 +106,35 @@ export const verifyChugSplashConfig = async (
     )
 
     // Verify the implementation
-    await attemptVerification(
-      hre.network.provider,
-      hre.network.name,
-      etherscanApiEndpoints,
-      implementationAddress,
-      sourceName,
-      contractName,
-      abi,
-      etherscanApiKey,
-      compilerInput.input,
-      compilerInput.solcVersion,
-      constructorArgValues
-    )
+    try {
+      await attemptVerification(
+        hre.network.provider,
+        hre.network.name,
+        etherscanApiEndpoints,
+        implementationAddress,
+        sourceName,
+        contractName,
+        abi,
+        etherscanApiKey,
+        compilerInput.input,
+        compilerInput.solcVersion,
+        constructorArgValues
+      )
+    } catch (err) {
+      console.error(err)
+    }
 
-    await linkProxyWithImplementation(
-      etherscanApiEndpoints,
-      etherscanApiKey,
-      proxyAddress,
-      implementationAddress,
-      contractName
-    )
+    try {
+      await linkProxyWithImplementation(
+        etherscanApiEndpoints,
+        etherscanApiKey,
+        proxyAddress,
+        implementationAddress,
+        contractName
+      )
+    } catch (err) {
+      console.error(err)
+    }
   }
 }
 


### PR DESCRIPTION
Prevents one request failure from halting the entire verification process.