### PR TITLE
fix(pg): remove progress bar on execution-related hardhat tasks

### DIFF
--- a/.changeset/slimy-apes-brake.md
+++ b/.changeset/slimy-apes-brake.md
@@ -1,0 +1,6 @@
+---
+'@chugsplash/core': patch
+'@chugsplash/plugins': patch
+---
+
+Remove progress bar in execution-related Hardhat tasks

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -207,7 +207,7 @@ export const displayDeploymentTable = (
     Object.entries(parsedConfig.contracts).forEach(
       ([referenceName, contractConfig], i) =>
         (deployments[i + 1] = {
-          Reference: referenceName,
+          'Reference Name': referenceName,
           Contract: contractConfig.contract,
           Address: contractConfig.address,
         })

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -34,7 +34,6 @@
     "@ethereumjs/common": "^3.0.1",
     "@ethereumjs/vm": "^6.2.0",
     "@ethersproject/abstract-provider": "^5.7.0",
-    "cli-progress": "^3.11.2",
     "dotenv": "^16.0.3",
     "ethers": "^5.6.9",
     "ipfs-http-client": "56.0.3",
@@ -45,8 +44,8 @@
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.2.1",
-    "hardhat": "^2.10.0",
-    "chai": "^4.3.6"
+    "chai": "^4.3.6",
+    "hardhat": "^2.10.0"
   },
   "peerDependencies": {
     "@nomiclabs/hardhat-ethers": "^2",

--- a/packages/plugins/src/hardhat/execution.ts
+++ b/packages/plugins/src/hardhat/execution.ts
@@ -2,12 +2,10 @@ import {
   ChugSplashBundleState,
   ChugSplashBundleStatus,
   ChugSplashConfig,
-  chugsplashLog,
   getChugSplashRegistry,
   getChugSplashManager,
 } from '@chugsplash/core'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
-import { SingleBar, Presets } from 'cli-progress'
 import { ethers } from 'ethers'
 import { ChugSplashManagerABI } from '@chugsplash/contracts'
 import { sleep } from '@eth-optimism/core-utils'
@@ -18,11 +16,8 @@ import { getFinalDeploymentTxnHash } from './deployments'
 export const monitorRemoteExecution = async (
   hre: HardhatRuntimeEnvironment,
   parsedConfig: ChugSplashConfig,
-  bundleId: string,
-  silent: boolean
+  bundleId: string
 ): Promise<string> => {
-  const progressBar = new SingleBar({}, Presets.shades_classic)
-
   const provider = hre.ethers.provider
 
   const projectName = parsedConfig.options.projectName
@@ -40,12 +35,6 @@ export const monitorRemoteExecution = async (
 
   // Handle cases where the bundle is not approved.
   if (bundleState.status === ChugSplashBundleStatus.CANCELLED) {
-    // Set the progress bar to be the number of executions that had occurred when the bundle was
-    // cancelled.
-    progressBar.start(
-      bundleState.executions.length,
-      bundleState.actionsExecuted
-    )
     throw new Error(`${projectName} was cancelled.`)
   } else if (bundleState.status === ChugSplashBundleStatus.EMPTY) {
     throw new Error(
@@ -67,12 +56,6 @@ approved for execution on ${hre.network.name}.`
   }
 
   // If we make it to this point, we know that the bundle is approved.
-
-  // Set the status bar to display the number of actions executed so far.
-  progressBar.start(
-    bundleState.executions.length,
-    bundleState.actionsExecuted.toNumber()
-  )
 
   while (bundleState.status === ChugSplashBundleStatus.APPROVED) {
     // Check if the available execution amount in the ChugSplashManager is too low to finish the
@@ -100,17 +83,11 @@ npx hardhat chugsplash-fund --network ${hre.network.name} --amount ${estCost} <c
     // Get the current bundle state.
     bundleState = await ChugSplashManager.bundles(bundleId)
 
-    // Update the progress bar.
-    progressBar.update(bundleState.actionsExecuted.toNumber())
-
     // Wait for one second.
     await sleep(1000)
   }
 
   if (bundleState.status === ChugSplashBundleStatus.COMPLETED) {
-    progressBar.update(bundleState.executions.length)
-    chugsplashLog('\n', silent)
-
     // Get the `completeChugSplashBundle` transaction.
     const finalDeploymentTxnHash = await getFinalDeploymentTxnHash(
       ChugSplashManager,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,38 @@
 # yarn lockfile v1
 
 
+"@amplitude/identify@^1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@amplitude/identify/-/identify-1.10.2.tgz#25d88f9e3bedd99701c777b9e44408ac69179aa1"
+  integrity sha512-ywxeabS8ukMdJWNwx3rG/EBngXFg/4NsPhlyAxbBUcI7HzBXEJUKepiZfkz8K6Y7f0mpc23Qz1aBf48ZJDZmkQ==
+  dependencies:
+    "@amplitude/types" "^1.10.2"
+    "@amplitude/utils" "^1.10.2"
+    tslib "^2.0.0"
+
+"@amplitude/node@^1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@amplitude/node/-/node-1.10.2.tgz#79fb80e7228486521156eae510de998264e6620c"
+  integrity sha512-E3xp8DOpkF5ThjrRlAmSocnrEYsTPpd3Zg4WdBLms0ackQSgQpw6z84+YMcoPerZHJJ/LEqdo4Cg4Z5Za3D+3Q==
+  dependencies:
+    "@amplitude/identify" "^1.10.2"
+    "@amplitude/types" "^1.10.2"
+    "@amplitude/utils" "^1.10.2"
+    tslib "^2.0.0"
+
+"@amplitude/types@^1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@amplitude/types/-/types-1.10.2.tgz#8f3c6c3c9ee24f401ee037b351c3c67eb945eefc"
+  integrity sha512-I8qenRI7uU6wKNb9LiZrAosSHVoNHziXouKY81CrqxH9xhVTEIJFXeuCV0hbtBr0Al/8ejnGjQRx+S2SvU/pPg==
+
+"@amplitude/utils@^1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@amplitude/utils/-/utils-1.10.2.tgz#ce77dc8a54fcd3843511531cc7d56363247c7ad8"
+  integrity sha512-tVsHXu61jITEtRjB7NugQ5cVDd4QDzne8T3ifmZye7TiJeUfVRvqe44gDtf55A+7VqhDhyEIIXTA1iVcDGqlEw==
+  dependencies:
+    "@amplitude/types" "^1.10.2"
+    tslib "^2.0.0"
+
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -2735,13 +2767,6 @@ cli-cursor@^3.1.0:
   integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
   dependencies:
     restore-cursor "^3.1.0"
-
-cli-progress@^3.11.2:
-  version "3.11.2"
-  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.11.2.tgz#f8c89bd157e74f3f2c43bcfb3505670b4d48fc77"
-  integrity sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==
-  dependencies:
-    string-width "^4.2.3"
 
 cli-spinners@^2.5.0:
   version "2.7.0"
@@ -7779,7 +7804,7 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-ts-node@^10.8.1:
+ts-node@^10.8.1, ts-node@^10.9.1:
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
@@ -7818,7 +7843,7 @@ tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0, tslib@^2.4.0:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==


### PR DESCRIPTION
This PR removes the progress bar that monitors the number of actions that've been executed so far in a bundle. I chose to remove it since we now execute most of the actions at once at the very beginning of the bundle, which pretty much defeats the purpose of a progress bar.