### PR TITLE
fix(ct): make chugsplashregistry proxy's address deterministic

### DIFF
--- a/.changeset/fuzzy-chairs-lick.md
+++ b/.changeset/fuzzy-chairs-lick.md
@@ -1,0 +1,7 @@
+---
+'@chugsplash/contracts': patch
+'@chugsplash/core': patch
+'@chugsplash/executor': patch
+---
+
+Make the ChugSplashRegistry proxy's address deterministic

--- a/packages/contracts/contracts/DeterministicProxyOwner.sol
+++ b/packages/contracts/contracts/DeterministicProxyOwner.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { Proxy } from "./libraries/Proxy.sol";
+
+/**
+ * @title DeterministicProxyOwner
+ */
+contract DeterministicProxyOwner is Initializable {
+    function initializeProxy(
+        address payable _proxy,
+        address _implementation,
+        address _newOwner
+    ) external initializer {
+        Proxy(_proxy).upgradeTo(_implementation);
+        Proxy(_proxy).changeAdmin(_newOwner);
+    }
+}

--- a/packages/contracts/src/constants.ts
+++ b/packages/contracts/src/constants.ts
@@ -10,6 +10,7 @@ import {
   ChugSplashManagerProxyArtifact,
   ChugSplashManagerABI,
   ProxyABI,
+  DeterministicProxyOwnerArtifact,
 } from './ifaces'
 
 const owner = '0x1A3DAA6F487A480c1aD312b90FD0244871940b66'
@@ -22,6 +23,7 @@ const chugsplashManagerSourceName = ChugSplashManagerArtifact.sourceName
 const proxyUpdaterSourceName = ProxyUpdaterArtifact.sourceName
 const defaultAdapterSourceName = DefaultAdapterArtifact.sourceName
 const chugsplashRegistyProxySourceName = ProxyArtifact.sourceName
+const deterministicOwnerSourceName = DeterministicProxyOwnerArtifact.sourceName
 
 const [chugsplashManagerConstructorFragment] = ChugSplashManagerABI.filter(
   (fragment) => fragment.type === 'constructor'
@@ -51,15 +53,24 @@ export const PROXY_UPDATER_ADDRESS = ethers.utils.getCreate2Address(
   ethers.utils.solidityKeccak256(['bytes'], [ProxyUpdaterArtifact.bytecode])
 )
 
+export const DETERMINISTIC_PROXY_OWNER_ADDRESS = ethers.utils.getCreate2Address(
+  DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
+  ethers.constants.HashZero,
+  ethers.utils.solidityKeccak256(
+    ['bytes'],
+    [DeterministicProxyOwnerArtifact.bytecode]
+  )
+)
+
 const [registryProxyConstructorFragment] = ProxyABI.filter(
   (fragment) => fragment.type === 'constructor'
 )
 const registryProxyConstructorArgTypes =
   registryProxyConstructorFragment.inputs.map((input) => input.type)
-const registryProxyConstructorArgValues = [CHUGSPLASH_BOOTLOADER_ADDRESS]
+const registryProxyConstructorArgValues = [DETERMINISTIC_PROXY_OWNER_ADDRESS]
 
 export const CHUGSPLASH_REGISTRY_PROXY_ADDRESS = ethers.utils.getCreate2Address(
-  CHUGSPLASH_BOOTLOADER_ADDRESS,
+  DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
   ethers.constants.HashZero,
   ethers.utils.solidityKeccak256(
     ['bytes', 'bytes'],
@@ -163,3 +174,4 @@ CHUGSPLASH_CONSTRUCTOR_ARGS[proxyUpdaterSourceName] = []
 CHUGSPLASH_CONSTRUCTOR_ARGS[defaultAdapterSourceName] = []
 CHUGSPLASH_CONSTRUCTOR_ARGS[chugsplashRegistyProxySourceName] =
   registryProxyConstructorArgValues
+CHUGSPLASH_CONSTRUCTOR_ARGS[deterministicOwnerSourceName] = []

--- a/packages/contracts/src/ifaces.ts
+++ b/packages/contracts/src/ifaces.ts
@@ -6,8 +6,9 @@ export const ChugSplashManagerArtifact = require('../artifacts/contracts/ChugSpl
 export const ProxyUpdaterArtifact = require('../artifacts/contracts/ProxyUpdater.sol/ProxyUpdater.json')
 export const DefaultAdapterArtifact = require('../artifacts/contracts/adapters/DefaultAdapter.sol/DefaultAdapter.json')
 export const ProxyArtifact = require('../artifacts/contracts/libraries/Proxy.sol/Proxy.json')
+export const DeterministicProxyOwnerArtifact = require('../artifacts/contracts/DeterministicProxyOwner.sol/DeterministicProxyOwner.json')
 
-export const buildInfo = require('../artifacts/build-info/a59148ffea63beedd50ee5352d54a7bc.json')
+export const buildInfo = require('../artifacts/build-info/3fa557b7889abe264f17b7551a4f2eed.json')
 
 export const ChugSplashRegistryABI = ChugSplashRegistryArtifact.abi
 export const ChugSplashBootLoaderABI = ChugSplashBootLoaderArtifact.abi
@@ -16,3 +17,4 @@ export const ChugSplashManagerABI = ChugSplashManagerArtifact.abi
 export const ProxyUpdaterABI = ProxyUpdaterArtifact.abi
 export const DefaultAdapterABI = DefaultAdapterArtifact.abi
 export const ProxyABI = ProxyArtifact.abi
+export const DeterministicProxyOwnerABI = DeterministicProxyOwnerArtifact.abi

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -225,3 +225,9 @@ export const claimExecutorPayment = async (
     await (await ChugSplashManager.claimExecutorPayment()).wait()
   }
 }
+
+export const getProxyOwner = async (Proxy: Contract) => {
+  // Use the latest `AdminChanged` event on the Proxy to get the most recent owner.
+  const { args } = (await Proxy.queryFilter('AdminChanged')).at(-1)
+  return args.newAdmin
+}

--- a/packages/executor/src/utils/initialize.ts
+++ b/packages/executor/src/utils/initialize.ts
@@ -16,6 +16,8 @@ import {
   CHUGSPLASH_MANAGER_ADDRESS,
   CHUGSPLASH_REGISTRY_ADDRESS,
   DEFAULT_ADAPTER_ADDRESS,
+  DeterministicProxyOwnerArtifact,
+  DETERMINISTIC_PROXY_OWNER_ADDRESS,
   buildInfo,
 } from '@chugsplash/contracts'
 
@@ -56,6 +58,10 @@ export const initializeChugSplashPredeploys = async (
       address: CHUGSPLASH_REGISTRY_ADDRESS,
     },
     { artifact: DefaultAdapterArtifact, address: DEFAULT_ADAPTER_ADDRESS },
+    {
+      artifact: DeterministicProxyOwnerArtifact,
+      address: DETERMINISTIC_PROXY_OWNER_ADDRESS,
+    },
   ]
 
   for (const { artifact, address } of contracts) {


### PR DESCRIPTION
This PR makes the ChugSplashRegistry proxy's address deterministic. This solves an issue where the addresses of the ChugSplash predeploys would change whenever a change to the ChugSplashManager was introduced. This would have made it difficult for identical contracts deployed using ChugSplash to share the same addresses across networks. For example, if we deployed the predeploys on Optimism, then made some changes to the ChugSplashManager, then deployed the predeploys on Ethereum, the addresses of the predeploys would be different across chains. Consequently, the addresses of identical contracts deployed by ChugSplash would be different too, since all addresses ultimately rely on the ChugSplashRegistry's proxy.

In order to address this issue, I made it so that the ChugSplashRegistry's proxy does not have dependencies on anything that can change in the future. This meant changing two things: the contract that deploys the proxy, and the address that initially owns the proxy (which is its sole constructor argument).

To solve the first issue, we now deploy the proxy using the DeterministicDeploymentProxy instead of the ChugSplashBootLoader, since the BootLoader's creation code changes every time a change is made to the ChugSplashManager (which in turn changes the address of the contracts deployed within the BootLoader). To solve the second issue, I introduced a DeterministicProxyOwner contract which initially owns the proxy instead of the random `0x1a3...` address. The DeterministicProxyOwner is deployed using the DeterministicDeploymentProxy. Once the ChugSplashRegistry's proxy and the DeterministicProxyOwner are deployed, ownership of the registry's proxy is transferred to the `0x1a3...` address.