### PR TITLE
fix(pg): deploy the executor once per cli command

### DIFF
--- a/.changeset/real-moons-count.md
+++ b/.changeset/real-moons-count.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/plugins': patch
+---
+
+Deploy the executor only once per CLI command


### PR DESCRIPTION
The executor can't be invoked more than once in a Hardhat task, which causes an error to be thrown if running e.g. `npx hardhat node --deploy-all`. This PR fixes this issue by spinning up only one executor maximum in a command.