### PR TITLE
Basic Support for Upgrades

### DIFF
--- a/.changeset/five-lemons-cry.md
+++ b/.changeset/five-lemons-cry.md
@@ -1,0 +1,6 @@
+---
+'@chugsplash/core': patch
+'@chugsplash/plugins': patch
+---
+
+Add basic support for upgrades

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -17,6 +17,7 @@ import {
   getChugSplashManager,
   getExecutionAmountToSendPlusBuffer,
   checkValidDeployment,
+  checkValidUpgrade,
 } from '@chugsplash/core'
 import { getChainId } from '@eth-optimism/core-utils'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
@@ -72,6 +73,7 @@ export const deployAllChugSplashConfigs = async (
       remoteExecution,
       ipfsUrl,
       noCompile,
+      false,
       executor,
       spinner
     )
@@ -85,6 +87,7 @@ export const deployChugSplashConfig = async (
   remoteExecution: boolean,
   ipfsUrl: string,
   noCompile: boolean,
+  isUpgrade: boolean,
   executor?: ChugSplashExecutor,
   spinner: ora.Ora = ora({ isSilent: true })
 ) => {
@@ -174,7 +177,9 @@ export const deployChugSplashConfig = async (
       bundle,
       configUri,
       remoteExecution,
-      ipfsUrl
+      ipfsUrl,
+      isUpgrade,
+      configPath
     )
     currBundleStatus = ChugSplashBundleStatus.PROPOSED
   }
@@ -330,9 +335,25 @@ export const proposeChugSplashBundle = async (
   bundle: ChugSplashActionBundle,
   configUri: string,
   remoteExecution: boolean,
-  ipfsUrl: string
+  ipfsUrl: string,
+  isUpgrade: boolean,
+  configPath: string
 ) => {
-  await checkValidDeployment(hre.ethers.provider, parsedConfig)
+  if (isUpgrade) {
+    await checkValidUpgrade(
+      hre.ethers.provider,
+      parsedConfig,
+      configPath,
+      hre.network.name
+    )
+  } else {
+    await checkValidDeployment(
+      hre.ethers.provider,
+      parsedConfig,
+      configPath,
+      hre.network.name
+    )
+  }
 
   const ChugSplashManager = getChugSplashManager(
     hre.ethers.provider.getSigner(),


### PR DESCRIPTION
## Purpose
Adds basic support for upgrading contracts via the `chugsplash-upgrade` task and the `isUpgrade` flag on the `chugsplash-deploy` task. 

## Note
There are still some more complex upgrade cases which we will need to handle to make this a really robust feature. 
- This PR does not handle cases where only some contracts in a config file need to be upgraded. If you attempt to upgrade a contract where the implementation code has not changed, you will encounter an error `ChugSplashManager: implementation was not deployed correctly`. This is due to create2 returning a zero address for the implementation address (I believe) due to the generated address already being in use.
- For the same reason, this PR also does not handle cases where only ChugSplash config variables have changed.
- This PR does not handle cases where only some config files need to be upgraded. I chose to wait on updating the `node`, `test`, and `run` commands to support upgrades due to this. 

We should discuss further how to handle these more complex upgrade cases. I recommend that we take inspiration from Terraform in the design of the upgrade process. This would involve using only the deploy task for both fresh deployments and upgrades. It would also involve dynamically detecting and upgrading only the contracts in a given config that have actually changed since the last deployment. 