### PR TITLE
fix: replace incorrect use of the `getDefaultProxyAddress` function

### DIFF
--- a/.changeset/mean-parents-relate.md
+++ b/.changeset/mean-parents-relate.md
@@ -1,0 +1,8 @@
+---
+'@chugsplash/core': patch
+'@chugsplash/demo': patch
+'@chugsplash/executor': patch
+'@chugsplash/plugins': patch
+---
+
+Replace incorrect use of the `getDefaultProxyAddress` function

--- a/packages/demo/chugsplash/SimpleStorage.config.ts
+++ b/packages/demo/chugsplash/SimpleStorage.config.ts
@@ -1,6 +1,6 @@
-import {  UserChugSplashConfig } from '@chugsplash/core'
+import { UserChugSplashConfig } from '@chugsplash/core'
 
-const config:  UserChugSplashConfig = {
+const config: UserChugSplashConfig = {
   // Configuration options for the project:
   options: {
     projectName: 'My First Project',

--- a/packages/executor/src/utils/etherscan.ts
+++ b/packages/executor/src/utils/etherscan.ts
@@ -5,7 +5,6 @@ import {
   CanonicalChugSplashConfig,
   CompilerInput,
   getChugSplashManagerProxyAddress,
-  getProxyAddress,
   parseChugSplashConfig,
   getConstructorArgs,
   chugsplashFetchSubtask,
@@ -101,7 +100,9 @@ export const verifyChugSplashConfig = async (
     console.error(err)
   }
 
-  for (const referenceName of Object.keys(canonicalConfig.contracts)) {
+  for (const [referenceName, contractConfig] of Object.entries(
+    canonicalConfig.contracts
+  )) {
     const artifact = artifacts[referenceName]
     const { abi, contractName, sourceName, compilerOutput } = artifact
     const { constructorArgValues } = getConstructorArgs(
@@ -113,10 +114,6 @@ export const verifyChugSplashConfig = async (
       contractName
     )
     const implementationAddress = await ChugSplashManager.implementations(
-      referenceName
-    )
-    const proxyAddress = getProxyAddress(
-      canonicalConfig.options.projectName,
       referenceName
     )
 
@@ -154,7 +151,7 @@ export const verifyChugSplashConfig = async (
       await linkProxyWithImplementation(
         etherscanApiEndpoints,
         etherscanApiKey,
-        proxyAddress,
+        contractConfig.address,
         implementationAddress,
         contractName
       )

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -6,7 +6,6 @@ import yesno from 'yesno'
 import { ethers } from 'ethers'
 import {
   ParsedChugSplashConfig,
-  getProxyAddress,
   isEmptyChugSplashConfig,
   registerChugSplashProject,
   ChugSplashBundleState,
@@ -284,18 +283,13 @@ ${configsWithFileNames.map(
 
   const { config: cfg } = configsWithFileNames[0]
 
-  if (
-    (await isProxyDeployed(
-      hre.ethers.provider,
-      cfg.options.projectName,
-      referenceName
-    )) === false
-  ) {
+  const proxyAddress = cfg.contracts[referenceName].address
+  if ((await isProxyDeployed(hre.ethers.provider, proxyAddress)) === false) {
     throw new Error(`You must first deploy ${referenceName}.`)
   }
 
   const Proxy = new ethers.Contract(
-    getProxyAddress(cfg.options.projectName, referenceName),
+    proxyAddress,
     new ethers.utils.Interface(
       getContractArtifact(cfg.contracts[referenceName].contract).abi
     ),


### PR DESCRIPTION
The `getDefaultProxyAddress` function (formerly known as `getProxyAddress`) was incorrectly being used to calculate the the proxy address in multiple packages. This was incorrect because it doesn't take into consideration that the user may have defined their own proxy address in the ChugSplash config, which means the default proxy wouldn't be used. This PR fixes this issue by using the `ContractConfig.address` member instead of calling `getDefaultProxyAddress`.