### PR TITLE
fix: update canonical config type usage

### DIFF
--- a/.changeset/wise-pumpkins-rush.md
+++ b/.changeset/wise-pumpkins-rush.md
@@ -1,0 +1,7 @@
+---
+'@chugsplash/core': patch
+'@chugsplash/executor': patch
+'@chugsplash/plugins': patch
+---
+
+Update canonical ChugSplash config type usage

--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -80,7 +80,7 @@ export const validateChugSplashConfig = (config: UserChugSplashConfig) => {
  */
 export const parseChugSplashConfig = (
   config: UserChugSplashConfig,
-  env: any = {}
+  env: any
 ): ParsedChugSplashConfig => {
   validateChugSplashConfig(config)
 
@@ -134,24 +134,18 @@ export const parseChugSplashConfig = (
  * @returns Action bundle generated from the parsed config file.
  */
 export const makeActionBundleFromConfig = async (
-  config: ParsedChugSplashConfig,
+  parsedConfig: ParsedChugSplashConfig,
   artifacts: {
     [name: string]: {
       creationCode: string
       storageLayout: SolidityStorageLayout
       immutableVariables: string[]
     }
-  },
-  env: {
-    [key: string]: string | number | boolean
-  } = {}
+  }
 ): Promise<ChugSplashActionBundle> => {
-  // Parse the config to replace any template variables.
-  const parsed = parseChugSplashConfig(config, env)
-
   const actions: ChugSplashAction[] = []
   for (const [referenceName, contractConfig] of Object.entries(
-    parsed.contracts
+    parsedConfig.contracts
   )) {
     const artifact = artifacts[referenceName]
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -37,9 +37,7 @@ export interface UserChugSplashConfig {
     projectName: string
     projectOwner: string
   }
-  contracts: {
-    [referenceName: string]: UserContractConfig
-  }
+  contracts: UserContractConfigs
 }
 
 /**
@@ -50,9 +48,7 @@ export interface ParsedChugSplashConfig {
     projectName: string
     projectOwner: string
   }
-  contracts: {
-    [referenceName: string]: ParsedContractConfig
-  }
+  contracts: ParsedContractConfigs
 }
 
 /**
@@ -61,9 +57,15 @@ export interface ParsedChugSplashConfig {
 export type UserContractConfig = {
   contract: string
   address?: string
-  variables?: {
-    [name: string]: UserConfigVariable
-  }
+  variables?: UserConfigVariables
+}
+
+export type UserContractConfigs = {
+  [referenceName: string]: UserContractConfig
+}
+
+export type UserConfigVariables = {
+  [name: string]: UserConfigVariable
 }
 
 /**
@@ -72,9 +74,15 @@ export type UserContractConfig = {
 export type ParsedContractConfig = {
   contract: string
   address: string
-  variables?: {
-    [name: string]: ParsedConfigVariable
-  }
+  variables?: ParsedConfigVariables
+}
+
+export type ParsedContractConfigs = {
+  [referenceName: string]: ParsedContractConfig
+}
+
+export type ParsedConfigVariables = {
+  [name: string]: ParsedConfigVariable
 }
 
 /**

--- a/packages/executor/src/utils/etherscan.ts
+++ b/packages/executor/src/utils/etherscan.ts
@@ -2,10 +2,8 @@ import assert from 'assert'
 
 import { ethers } from 'ethers'
 import {
-  CanonicalChugSplashConfig,
   CompilerInput,
   getChugSplashManagerProxyAddress,
-  parseChugSplashConfig,
   getConstructorArgs,
   chugsplashFetchSubtask,
   getMinimumCompilerInput,
@@ -54,7 +52,7 @@ import {
 } from '@chugsplash/contracts'
 import { request } from 'undici'
 
-import { getArtifactsFromParsedCanonicalConfig } from './compile'
+import { getArtifactsFromCanonicalConfig } from './compile'
 import { etherscanApiKey as apiKey, customChains } from './constants'
 
 export interface EtherscanResponseBody {
@@ -76,9 +74,7 @@ export const verifyChugSplashConfig = async (
   )
 
   const canonicalConfig = await chugsplashFetchSubtask({ configUri })
-  const artifacts = await getArtifactsFromParsedCanonicalConfig(
-    parseChugSplashConfig(canonicalConfig) as CanonicalChugSplashConfig
-  )
+  const artifacts = await getArtifactsFromCanonicalConfig(canonicalConfig)
   const ChugSplashManager = new ethers.Contract(
     getChugSplashManagerProxyAddress(canonicalConfig.options.projectName),
     ChugSplashManagerABI,

--- a/packages/plugins/src/hardhat/tasks.ts
+++ b/packages/plugins/src/hardhat/tasks.ts
@@ -20,7 +20,6 @@ import {
   ChugSplashBundleStatus,
   registerChugSplashProject,
   getChugSplashRegistry,
-  parseChugSplashConfig,
   displayDeploymentTable,
   getChugSplashManagerProxyAddress,
   getChugSplashManager,
@@ -39,7 +38,7 @@ import * as dotenv from 'dotenv'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import {
   ChugSplashExecutor,
-  getArtifactsFromParsedCanonicalConfig,
+  getArtifactsFromCanonicalConfig,
 } from '@chugsplash/executor'
 
 import {
@@ -100,19 +99,11 @@ subtask(TASK_CHUGSPLASH_FETCH)
 export const bundleRemoteSubtask = async (args: {
   canonicalConfig: CanonicalChugSplashConfig
 }): Promise<ChugSplashActionBundle> => {
-  const parsedCanonicalConfig = parseChugSplashConfig(
-    args.canonicalConfig
-  ) as CanonicalChugSplashConfig
+  const { canonicalConfig } = args
 
-  const artifacts = await getArtifactsFromParsedCanonicalConfig(
-    parsedCanonicalConfig
-  )
+  const artifacts = await getArtifactsFromCanonicalConfig(canonicalConfig)
 
-  return makeActionBundleFromConfig(
-    parsedCanonicalConfig,
-    artifacts,
-    process.env
-  )
+  return makeActionBundleFromConfig(canonicalConfig, artifacts)
 }
 
 subtask(TASK_CHUGSPLASH_BUNDLE_REMOTE)
@@ -157,7 +148,7 @@ export const bundleLocalSubtask = async (args: {
     }
   }
 
-  return makeActionBundleFromConfig(parsedConfig, artifacts, process.env)
+  return makeActionBundleFromConfig(parsedConfig, artifacts)
 }
 
 subtask(TASK_CHUGSPLASH_BUNDLE_LOCAL)

--- a/packages/plugins/src/hardhat/utils.ts
+++ b/packages/plugins/src/hardhat/utils.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 
+import * as dotenv from 'dotenv'
 import {
   ParsedChugSplashConfig,
   getChugSplashManagerProxyAddress,
@@ -9,6 +10,9 @@ import {
 } from '@chugsplash/core'
 import { TASK_COMPILE, TASK_CLEAN } from 'hardhat/builtin-tasks/task-names'
 import { Signer } from 'ethers'
+
+// Load environment variables from .env
+dotenv.config()
 
 export const writeHardhatSnapshotId = async (
   hre: any,


### PR DESCRIPTION
Also updates the logic that injects .env variables into the ChugSplash config by routing the env variables through the `loadParsedChugSplashConfig` function.