### PR TITLE
fix(ct): change implementation contract deployment from create2 to create

### DIFF
--- a/.changeset/famous-lemons-end.md
+++ b/.changeset/famous-lemons-end.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/contracts': patch
+---
+
+Change implementation contract deployment from create2 to create

--- a/packages/contracts/contracts/ChugSplashManager.sol
+++ b/packages/contracts/contracts/ChugSplashManager.sol
@@ -816,12 +816,9 @@ contract ChugSplashManager is OwnableUpgradeable, ReentrancyGuardUpgradeable {
      * @param _code   Creation bytecode of the implementation contract.
      */
     function _deployImplementation(string memory _target, bytes memory _code) internal {
-        // Get the expected address of the implementation contract.
-        address expectedImplementation = Create2.compute(address(this), bytes32(0), _code);
-
         address implementation;
         assembly {
-            implementation := create2(0x0, add(_code, 0x20), mload(_code), 0x0)
+            implementation := create(0x0, add(_code, 0x20), mload(_code))
         }
 
         // Could happen if insufficient gas is supplied to this transaction, should not
@@ -829,7 +826,7 @@ contract ChugSplashManager is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         // standard OOG, then this would halt the entire contract.
         // TODO: Make sure this cannot happen in any case other than OOG.
         require(
-            expectedImplementation == implementation,
+            implementation != address(0),
             "ChugSplashManager: implementation was not deployed correctly"
         );
 

--- a/packages/contracts/src/ifaces.ts
+++ b/packages/contracts/src/ifaces.ts
@@ -8,7 +8,7 @@ export const DefaultAdapterArtifact = require('../artifacts/contracts/adapters/D
 export const ProxyArtifact = require('../artifacts/contracts/libraries/Proxy.sol/Proxy.json')
 export const DeterministicProxyOwnerArtifact = require('../artifacts/contracts/DeterministicProxyOwner.sol/DeterministicProxyOwner.json')
 
-export const buildInfo = require('../artifacts/build-info/1070f6de75e083a61ed5f1303beedb95.json')
+export const buildInfo = require('../artifacts/build-info/e2689fa8b28e57eb1a58836e6f354f84.json')
 
 export const ChugSplashRegistryABI = ChugSplashRegistryArtifact.abi
 export const ChugSplashBootLoaderABI = ChugSplashBootLoaderArtifact.abi

--- a/packages/contracts/test/ChugSplashManager.t.sol
+++ b/packages/contracts/test/ChugSplashManager.t.sol
@@ -380,11 +380,11 @@ contract ChugSplashManager_Test is Test {
         helper_proposeThenApproveThenFundThenClaimBundle();
         address payable proxyAddress = manager.getProxyByTargetName(firstAction.target);
         assertEq(proxyAddress.code.length, 0);
-        address implementationAddress = Create2.compute(
-            address(manager),
-            bytes32(0),
-            firstAction.data
-        );
+
+        // We add 1 here to account for the Proxy deployment that occurs before the implementation deployment.
+        uint256 implementationDeploymentNonce = 1 + vm.getNonce(address(manager));
+        
+        address implementationAddress = computeCreateAddress(address(manager), implementationDeploymentNonce);
         assertEq(implementationAddress.code.length, 0);
         uint256 initialTotalDebt = manager.totalDebt();
         uint256 initialExecutorDebt = manager.debt(executor1);


### PR DESCRIPTION
The primary reason for this change is to support the following scenario, which is currently prevented by our use of create2. Say we have two contracts in the same ChugSplash config that have the same creation bytecode, but different runtime bytecode. For example, the two contracts could have an immutable variable with different values. Currently, the create2 call from the ChugSplashManager fails because only one of these addresses can be deployed at the deterministically calculated address. Using the `create` opcode solves this.