### PR TITLE
fix(ct): add events for default proxy and implementation contract deployment

### DIFF
--- a/.changeset/funny-boats-sort.md
+++ b/.changeset/funny-boats-sort.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/contracts': patch
+---
+
+Add events for default proxy and implementation contract deployment

--- a/packages/contracts/src/ifaces.ts
+++ b/packages/contracts/src/ifaces.ts
@@ -8,7 +8,7 @@ export const DefaultAdapterArtifact = require('../artifacts/contracts/adapters/D
 export const ProxyArtifact = require('../artifacts/contracts/libraries/Proxy.sol/Proxy.json')
 export const DeterministicProxyOwnerArtifact = require('../artifacts/contracts/DeterministicProxyOwner.sol/DeterministicProxyOwner.json')
 
-export const buildInfo = require('../artifacts/build-info/c93098d4628e71d7804f716534a1a112.json')
+export const buildInfo = require('../artifacts/build-info/a68c760c056a61c3bf688bc630e7a150.json')
 
 export const ChugSplashRegistryABI = ChugSplashRegistryArtifact.abi
 export const ChugSplashBootLoaderABI = ChugSplashBootLoaderArtifact.abi


### PR DESCRIPTION
This makes it easy to get the deployment transaction hash of these contracts when they're deployed by the ChugSplashManager, which we'll need when generating their deployment artifacts.