### PR TITLE
maint(exec): clean up config and others

### DIFF
--- a/.changeset/dirty-cats-cough.md
+++ b/.changeset/dirty-cats-cough.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/executor': minor
+---
+
+Cleans up executor configuration and other small cleanups

--- a/packages/executor/.env.example
+++ b/packages/executor/.env.example
@@ -1,5 +1,5 @@
 CHUGSPLASH_EXECUTOR__PRIVATE_KEY=<private key to deploy with>
-CHUGSPLASH_EXECUTOR__URL=<url of the network to monitor, http://host.docker.internal:8545 for local node>
+CHUGSPLASH_EXECUTOR__PROVIDER=<url of the network to monitor, http://host.docker.internal:8545 for local node>
 CHUGSPLASH_EXECUTOR__NETWORK=<name of the target network, used to fetch the etherscan verification endpoint>
 CHUGSPLASH_EXECUTOR__AMPLITUDE_KEY=<amplitude api key for analytics (optional)>
 CHUGSPLASH_EXECUTOR__LOG_LEVEL=<filter logs based on this level, i.e 'error', 'warning', 'info'>


### PR DESCRIPTION
Cleans up executor configuration and makes a few small tweaks to make the executor more idiomatic for BaseServiceV2.