### PR TITLE
fix(pg): write canonical config to file system when using executing bundles locally

### DIFF
--- a/.changeset/sour-shrimps-work.md
+++ b/.changeset/sour-shrimps-work.md
@@ -1,0 +1,7 @@
+---
+'@chugsplash/core': patch
+'@chugsplash/executor': patch
+'@chugsplash/plugins': patch
+---
+
+Write canonical config to file system when using executing bundles locally

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -11,7 +11,7 @@ import {
   ProxyABI,
 } from '@chugsplash/contracts'
 
-import { ParsedChugSplashConfig } from './config'
+import { CanonicalChugSplashConfig, ParsedChugSplashConfig } from './config'
 import { ChugSplashActionBundle, ChugSplashActionType } from './actions'
 
 export const computeBundleId = (
@@ -362,4 +362,40 @@ export const formatEther = (
   decimals: number
 ): string => {
   return parseFloat(ethers.utils.formatEther(amount)).toFixed(decimals)
+}
+
+export const readCanonicalConfig = (
+  canonicalConfigFolderPath: string,
+  bundleId: string
+): CanonicalChugSplashConfig => {
+  // Check that the file containing the canonical config exists.
+  const canonicalConfigPath = path.join(
+    canonicalConfigFolderPath,
+    `${bundleId}.json`
+  )
+  if (!fs.existsSync(canonicalConfigPath)) {
+    throw new Error(
+      `Could not find local bundle ID file. Please report this error.`
+    )
+  }
+
+  return JSON.parse(fs.readFileSync(canonicalConfigPath, 'utf8'))
+}
+
+export const writeCanonicalConfig = (
+  canonicalConfigFolderPath: string,
+  bundleId: string,
+  canonicalConfig: CanonicalChugSplashConfig
+) => {
+  // Create the canonical config folder if it doesn't already exist.
+  if (!fs.existsSync(canonicalConfigFolderPath)) {
+    fs.mkdirSync(canonicalConfigFolderPath)
+  }
+
+  // Write the canonical config to the local file system. It will exist in a JSON file that has the
+  // bundle ID as its name.
+  fs.writeFileSync(
+    path.join(canonicalConfigFolderPath, `${bundleId}.json`),
+    JSON.stringify(canonicalConfig, null, 2)
+  )
 }

--- a/packages/executor/src/utils/compile.ts
+++ b/packages/executor/src/utils/compile.ts
@@ -147,16 +147,12 @@ export const getArtifactsFromCanonicalConfig = async (
  * @returns Compiled ChugSplashBundle.
  */
 export const compileRemoteBundle = async (
-  configUri: string,
-  canonicalConfig?: CanonicalChugSplashConfig
+  configUri: string
 ): Promise<{
   bundle: ChugSplashActionBundle
   canonicalConfig: CanonicalChugSplashConfig
 }> => {
-  // canonicalConfig is passed in when executing a local deployment
-  if (!canonicalConfig) {
-    canonicalConfig = await chugsplashFetchSubtask({ configUri })
-  }
+  const canonicalConfig = await chugsplashFetchSubtask({ configUri })
 
   const bundle = await bundleRemoteSubtask({ canonicalConfig })
   return { bundle, canonicalConfig }

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -129,17 +129,16 @@ export const deployChugSplashConfig = async (
   }
 
   // Get the bundle ID without publishing anything to IPFS.
-  const { bundleId, bundle, configUri, canonicalConfig } =
-    await chugsplashCommitSubtask(
-      {
-        parsedConfig,
-        ipfsUrl,
-        commitToIpfs: false,
-        noCompile,
-        spinner,
-      },
-      hre
-    )
+  const { bundleId, bundle, configUri } = await chugsplashCommitSubtask(
+    {
+      parsedConfig,
+      ipfsUrl,
+      commitToIpfs: false,
+      noCompile,
+      spinner,
+    },
+    hre
+  )
 
   spinner.start(`Checking the status of ${projectName}...`)
 
@@ -216,7 +215,7 @@ export const deployChugSplashConfig = async (
   if (remoteExecution) {
     await monitorExecution(hre, parsedConfig, bundle, bundleId, spinner)
   } else {
-    // If executing locally, then startup executor with HRE provider and pass in canonical config
+    // Use the in-process executor if executing the bundle locally.
     spinner.start('Executing project...')
     const amountToDeposit = await getAmountToDeposit(
       provider,
@@ -229,7 +228,7 @@ export const deployChugSplashConfig = async (
       to: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
       value: amountToDeposit,
     })
-    await executor.main(canonicalConfig)
+    await executor.main(bundleId, hre.config.paths.canonicalConfigs)
     spinner.succeed(`Executed ${projectName}.`)
   }
 

--- a/packages/plugins/src/hardhat/tasks.ts
+++ b/packages/plugins/src/hardhat/tasks.ts
@@ -34,6 +34,7 @@ import {
   getAmountToDeposit,
   EXECUTION_BUFFER_MULTIPLIER,
   formatEther,
+  writeCanonicalConfig,
 } from '@chugsplash/core'
 import { ChugSplashManagerABI, ProxyABI } from '@chugsplash/contracts'
 import ora from 'ora'
@@ -583,12 +584,11 @@ export const chugsplashCommitSubtask = async (
     noCompile: boolean
     spinner?: ora.Ora
   },
-  hre
+  hre: HardhatRuntimeEnvironment
 ): Promise<{
   bundle: ChugSplashActionBundle
   configUri: string
   bundleId: string
-  canonicalConfig: CanonicalChugSplashConfig
 }> => {
   const { parsedConfig, ipfsUrl, commitToIpfs, noCompile, spinner } = args
 
@@ -699,6 +699,15 @@ IPFS_API_KEY_SECRET: ...
     configUri
   )
 
+  // Write the canonical config to the local file system if we aren't committing it to IPFS.
+  if (!commitToIpfs) {
+    writeCanonicalConfig(
+      hre.config.paths.canonicalConfigs,
+      bundleId,
+      canonicalConfig
+    )
+  }
+
   if (spinner) {
     commitToIpfs
       ? spinner.succeed(
@@ -709,7 +718,7 @@ IPFS_API_KEY_SECRET: ...
         )
   }
 
-  return { bundle, configUri, bundleId, canonicalConfig }
+  return { bundle, configUri, bundleId }
 }
 
 subtask(TASK_CHUGSPLASH_COMMIT)
@@ -1700,7 +1709,7 @@ export const chugsplashInitTask = async (
   args: {
     silent: boolean
   },
-  hre: any
+  hre: HardhatRuntimeEnvironment
 ) => {
   const { silent } = args
 

--- a/packages/plugins/src/hardhat/type-extensions.ts
+++ b/packages/plugins/src/hardhat/type-extensions.ts
@@ -18,6 +18,7 @@ declare module 'hardhat/types/config' {
   export interface ProjectPathsConfig {
     chugsplash: string
     deployments: string
+    canonicalConfigs: string
   }
 }
 
@@ -35,6 +36,10 @@ declare module 'hardhat/types/runtime' {
 extendConfig((config: HardhatConfig) => {
   config.paths.chugsplash = path.join(config.paths.root, 'chugsplash')
   config.paths.deployments = path.join(config.paths.root, 'deployments')
+  config.paths.canonicalConfigs = path.join(
+    config.paths.root,
+    '.canonical-configs'
+  )
 })
 
 extendEnvironment((hre: HardhatRuntimeEnvironment) => {


### PR DESCRIPTION
This is a necessary change to support the `chugsplash-diff` task on the Hardhat network, since there was previously no way to retrieve the canonical config aside from committing to IPFS.