### PR TITLE
fix(ct): add a universal salt that makes it easy to deploy new versions of the ChugSplash pre-deploys

### DIFF
--- a/.changeset/hot-news-build.md
+++ b/.changeset/hot-news-build.md
@@ -1,0 +1,6 @@
+---
+'@chugsplash/contracts': patch
+'@chugsplash/core': patch
+---
+
+Adds a universal salt that makes it easy to deploy new versions of the ChugSplash contracts

--- a/packages/contracts/contracts/ChugSplashBootLoader.sol
+++ b/packages/contracts/contracts/ChugSplashBootLoader.sol
@@ -49,6 +49,8 @@ contract ChugSplashBootLoader is Initializable {
      *                                   denominated as a percentage.
      * @param _managerImplementation     Address of the ChugSplashManager implementation contract.
      * @param _registryProxy             Address of the ChugSplashRegistry's proxy.
+     * @param _salt                      Salt to be used in the `CREATE2` calls that deploy the
+     *                                   contracts.
      */
     function initialize(
         address _owner,
@@ -57,13 +59,14 @@ contract ChugSplashBootLoader is Initializable {
         uint256 _ownerBondAmount,
         uint256 _executorPaymentPercentage,
         address _managerImplementation,
-        address _registryProxy
+        address _registryProxy,
+        bytes32 _salt
     ) external initializer {
         // Deploy the ProxyUpdater.
-        proxyUpdater = new ProxyUpdater{ salt: bytes32(0) }();
+        proxyUpdater = new ProxyUpdater{ salt: _salt }();
 
         // Deploy the root ChugSplashManager's proxy.
-        rootManagerProxy = new ChugSplashManagerProxy{ salt: bytes32(0) }(
+        rootManagerProxy = new ChugSplashManagerProxy{ salt: _salt }(
             ChugSplashRegistry(_registryProxy),
             address(this)
         );
@@ -78,7 +81,7 @@ contract ChugSplashBootLoader is Initializable {
         rootManagerProxy.changeAdmin(_owner);
 
         // Deploy and initialize the ChugSplashRegistry's implementation contract.
-        registryImplementation = new ChugSplashRegistry{ salt: bytes32(0) }(
+        registryImplementation = new ChugSplashRegistry{ salt: _salt }(
             address(proxyUpdater),
             _ownerBondAmount,
             _executorBondAmount,

--- a/packages/contracts/contracts/ProxyInitializer.sol
+++ b/packages/contracts/contracts/ProxyInitializer.sol
@@ -28,12 +28,13 @@ contract ProxyInitializer is Initializable {
      *         the initializer.
      *
      * @param _newOwner Address that will receive ownership of the proxy in the initializer.
+     * @param _salt Salt to be used in the `CREATE2` call that deploys the proxy.
      */
-    constructor(address _newOwner) {
+    constructor(address _newOwner, bytes32 _salt) {
         newOwner = _newOwner;
 
         // Deploy the proxy.
-        proxy = new Proxy{ salt: bytes32(0) }(
+        proxy = new Proxy{ salt: _salt }(
             // The owner must initially be this contract so that it can set the proxy's
             // implementation contract in the initializer.
             address(this)

--- a/packages/contracts/src/constants.ts
+++ b/packages/contracts/src/constants.ts
@@ -17,6 +17,8 @@ import {
 export const OWNER_MULTISIG_ADDRESS =
   '0xB1251e3Bd0EFf7852dF6ea3F11D73b0b28eA4aA8'
 
+export const CHUGSPLASH_SALT = '0x' + '11'.repeat(32)
+
 const chugsplashRegistrySourceName = ChugSplashRegistryArtifact.sourceName
 const chugsplashBootLoaderSourceName = ChugSplashBootLoaderArtifact.sourceName
 const chugsplashManagerProxySourceName =
@@ -32,7 +34,10 @@ const [proxyInitializerConstructorFragment] = ProxyInitializerABI.filter(
 )
 const proxyInitializerConstructorArgTypes =
   proxyInitializerConstructorFragment.inputs.map((input) => input.type)
-const proxyInitializerConstructorArgValues = [OWNER_MULTISIG_ADDRESS]
+const proxyInitializerConstructorArgValues = [
+  OWNER_MULTISIG_ADDRESS,
+  CHUGSPLASH_SALT,
+]
 
 const [chugsplashManagerConstructorFragment] = ChugSplashManagerABI.filter(
   (fragment) => fragment.type === 'constructor'
@@ -49,7 +54,7 @@ export const EXECUTOR_PAYMENT_PERCENTAGE = 20
 
 export const CHUGSPLASH_BOOTLOADER_ADDRESS = ethers.utils.getCreate2Address(
   DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
-  ethers.utils.solidityKeccak256(['string'], ['ChugSplashBootLoader']),
+  CHUGSPLASH_SALT,
   ethers.utils.solidityKeccak256(
     ['bytes'],
     [ChugSplashBootLoaderArtifact.bytecode]
@@ -58,13 +63,13 @@ export const CHUGSPLASH_BOOTLOADER_ADDRESS = ethers.utils.getCreate2Address(
 
 export const PROXY_UPDATER_ADDRESS = ethers.utils.getCreate2Address(
   CHUGSPLASH_BOOTLOADER_ADDRESS,
-  ethers.constants.HashZero,
+  CHUGSPLASH_SALT,
   ethers.utils.solidityKeccak256(['bytes'], [ProxyUpdaterArtifact.bytecode])
 )
 
 export const PROXY_INITIALIZER_ADDRESS = ethers.utils.getCreate2Address(
   DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
-  ethers.constants.HashZero,
+  CHUGSPLASH_SALT,
   ethers.utils.solidityKeccak256(
     ['bytes', 'bytes'],
     [
@@ -86,7 +91,7 @@ const registryProxyConstructorArgValues = [PROXY_INITIALIZER_ADDRESS]
 
 export const CHUGSPLASH_REGISTRY_PROXY_ADDRESS = ethers.utils.getCreate2Address(
   PROXY_INITIALIZER_ADDRESS,
-  ethers.constants.HashZero,
+  CHUGSPLASH_SALT,
   ethers.utils.solidityKeccak256(
     ['bytes', 'bytes'],
     [
@@ -102,7 +107,7 @@ export const CHUGSPLASH_REGISTRY_PROXY_ADDRESS = ethers.utils.getCreate2Address(
 export const ROOT_CHUGSPLASH_MANAGER_PROXY_ADDRESS =
   ethers.utils.getCreate2Address(
     CHUGSPLASH_BOOTLOADER_ADDRESS,
-    ethers.constants.HashZero,
+    CHUGSPLASH_SALT,
     ethers.utils.solidityKeccak256(
       ['bytes', 'bytes'],
       [
@@ -128,7 +133,7 @@ const chugsplashManagerConstructorArgValues = [
 
 export const CHUGSPLASH_MANAGER_ADDRESS = ethers.utils.getCreate2Address(
   DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
-  ethers.constants.HashZero,
+  CHUGSPLASH_SALT,
   ethers.utils.solidityKeccak256(
     ['bytes', 'bytes'],
     [
@@ -143,7 +148,7 @@ export const CHUGSPLASH_MANAGER_ADDRESS = ethers.utils.getCreate2Address(
 
 export const CHUGSPLASH_REGISTRY_ADDRESS = ethers.utils.getCreate2Address(
   CHUGSPLASH_BOOTLOADER_ADDRESS,
-  ethers.constants.HashZero,
+  CHUGSPLASH_SALT,
   ethers.utils.solidityKeccak256(
     ['bytes', 'bytes'],
     [
@@ -165,7 +170,7 @@ export const CHUGSPLASH_REGISTRY_ADDRESS = ethers.utils.getCreate2Address(
 
 export const DEFAULT_ADAPTER_ADDRESS = ethers.utils.getCreate2Address(
   DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
-  ethers.utils.solidityKeccak256(['string'], ['DefaultAdapter']),
+  CHUGSPLASH_SALT,
   ethers.utils.solidityKeccak256(['bytes'], [DefaultAdapterArtifact.bytecode])
 )
 

--- a/packages/contracts/src/ifaces.ts
+++ b/packages/contracts/src/ifaces.ts
@@ -8,7 +8,7 @@ export const DefaultAdapterArtifact = require('../artifacts/contracts/adapters/D
 export const ProxyArtifact = require('../artifacts/contracts/libraries/Proxy.sol/Proxy.json')
 export const ProxyInitializerArtifact = require('../artifacts/contracts/ProxyInitializer.sol/ProxyInitializer.json')
 
-export const buildInfo = require('../artifacts/build-info/8937e3b5ee14db19c324042441a75b73.json')
+export const buildInfo = require('../artifacts/build-info/0d07ba6058c55798a6fa4cbe1691d495.json')
 
 export const ChugSplashRegistryABI = ChugSplashRegistryArtifact.abi
 export const ChugSplashBootLoaderABI = ChugSplashBootLoaderArtifact.abi

--- a/packages/contracts/test/ChugSplashRegistry.t.sol
+++ b/packages/contracts/test/ChugSplashRegistry.t.sol
@@ -33,6 +33,7 @@ contract ChugSplashRegistry_Test is Test {
     address owner = address(128);
     address adapter = address(256);
     bytes32 proxyType = bytes32(hex"1337");
+    bytes32 salt = bytes32(hex"11");
     address dummyRegistryProxyAddress = address(1);
     string projectName = 'TestProject';
     uint256 ownerBondAmount = 10e8 gwei; // 0.1 ETH
@@ -47,7 +48,7 @@ contract ChugSplashRegistry_Test is Test {
     function setUp() external {
         proxyUpdater = new ProxyUpdater();
 
-        manager = new ChugSplashManager{ salt: bytes32(0) }(
+        manager = new ChugSplashManager{ salt: salt }(
             ChugSplashRegistry(dummyRegistryProxyAddress),
             projectName,
             owner,
@@ -58,7 +59,7 @@ contract ChugSplashRegistry_Test is Test {
             executorPaymentPercentage
         );
 
-        registry = new ChugSplashRegistry{ salt: bytes32(0) }(
+        registry = new ChugSplashRegistry{ salt: salt }(
             address(proxyUpdater),
             ownerBondAmount,
             executorBondAmount,

--- a/packages/contracts/test/integration-tests.t.sol
+++ b/packages/contracts/test/integration-tests.t.sol
@@ -13,6 +13,7 @@ import { Create2 } from "../contracts/libraries/Create2.sol";
 contract Integration_Tests is Test {
 
     address owner = address(128);
+    bytes32 salt = bytes32(hex"11");
     string projectName = 'TestProject';
     uint256 ownerBondAmount = 10e8 gwei; // 0.1 ETH
     uint256 executorBondAmount = 1 ether;
@@ -23,11 +24,11 @@ contract Integration_Tests is Test {
     Proxy registryProxy;
 
     function setUp() external {
-        bootloader = new ChugSplashBootLoader{salt: bytes32(0) }();
+        bootloader = new ChugSplashBootLoader{salt: salt }();
 
         address registryProxyAddress = Create2.compute(
             address(this),
-            bytes32(0),
+            salt,
             abi.encodePacked(type(Proxy).creationCode, abi.encode(address(owner)))
         );
 
@@ -38,10 +39,11 @@ contract Integration_Tests is Test {
             ownerBondAmount,
             executorPaymentPercentage,
             address(1),
-            registryProxyAddress
+            registryProxyAddress,
+            salt
         );
 
-        registryProxy = new Proxy{ salt: bytes32(0)}(owner);
+        registryProxy = new Proxy{ salt: salt }(owner);
 
         vm.startPrank(owner);
         registryProxy.upgradeTo(address(bootloader.registryImplementation()));

--- a/packages/core/src/languages/solidity/predeploys.ts
+++ b/packages/core/src/languages/solidity/predeploys.ts
@@ -23,6 +23,7 @@ import {
   CHUGSPLASH_REGISTRY_ADDRESS,
   OWNER_MULTISIG_ADDRESS,
   PROXY_INITIALIZER_ADDRESS,
+  CHUGSPLASH_SALT,
 } from '@chugsplash/contracts'
 import { Logger } from '@eth-optimism/common-ts'
 import { sleep } from '@eth-optimism/core-utils'
@@ -49,7 +50,7 @@ export const initializeChugSplash = async (
       abi: ChugSplashManagerABI,
       bytecode: ChugSplashManagerArtifact.bytecode,
     },
-    salt: ethers.constants.HashZero,
+    salt: CHUGSPLASH_SALT,
     args: CHUGSPLASH_CONSTRUCTOR_ARGS[ChugSplashManagerArtifact.sourceName],
   })
 
@@ -63,7 +64,7 @@ export const initializeChugSplash = async (
       abi: ChugSplashBootLoaderABI,
       bytecode: ChugSplashBootLoaderArtifact.bytecode,
     },
-    salt: ethers.utils.solidityKeccak256(['string'], ['ChugSplashBootLoader']),
+    salt: CHUGSPLASH_SALT,
   })
 
   logger?.info('[ChugSplash]: ChugSplashBootLoader deployed')
@@ -86,7 +87,8 @@ export const initializeChugSplash = async (
         OWNER_BOND_AMOUNT,
         EXECUTOR_PAYMENT_PERCENTAGE,
         ChugSplashManager.address,
-        CHUGSPLASH_REGISTRY_PROXY_ADDRESS
+        CHUGSPLASH_REGISTRY_PROXY_ADDRESS,
+        CHUGSPLASH_SALT
       )
     ).wait()
     logger?.info('[ChugSplash]: ChugSplashBootLoader initialized')
@@ -110,7 +112,7 @@ export const initializeChugSplash = async (
       abi: ProxyInitializerABI,
       bytecode: ProxyInitializerArtifact.bytecode,
     },
-    salt: ethers.constants.HashZero,
+    salt: CHUGSPLASH_SALT,
     args: CHUGSPLASH_CONSTRUCTOR_ARGS[ProxyInitializerArtifact.sourceName],
   })
 
@@ -185,7 +187,7 @@ export const initializeChugSplash = async (
       abi: DefaultAdapterABI,
       bytecode: DefaultAdapterArtifact.bytecode,
     },
-    salt: ethers.utils.solidityKeccak256(['string'], ['DefaultAdapter']),
+    salt: CHUGSPLASH_SALT,
   })
 
   logger?.info('[ChugSplash]: DefaultAdapter deployed')


### PR DESCRIPTION
To deploy a new version of the ChugSplash pre-deploy contracts, simply change the `CHUGSPLASH_SALT` value in `constants.ts` within the contracts package.