### PR TITLE
fix(ct): use `tx.gasprice` instead of `block.basefee`

### DIFF
--- a/.changeset/chatty-geckos-check.md
+++ b/.changeset/chatty-geckos-check.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/contracts': patch
+---
+
+Use `tx.gasprice` instead of `block.basefee`

--- a/packages/contracts/contracts/ChugSplashManager.sol
+++ b/packages/contracts/contracts/ChugSplashManager.sol
@@ -601,13 +601,15 @@ contract ChugSplashManager is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         // debt.
         uint256 executorPayment;
         if (block.chainid != 10 && block.chainid != 420) {
-            // Use the basefee for any network that isn't Optimism.
-            executorPayment = (block.basefee * gasUsed * (100 + executorPaymentPercentage)) / 100;
+            // Use the gas price for any network that isn't Optimism.
+            executorPayment = (tx.gasprice * gasUsed * (100 + executorPaymentPercentage)) / 100;
         } else if (block.chainid == 10) {
-            // Optimism mainnet does not have the basefee opcode, so we hardcode its value here.
+            // Optimism mainnet does not include `tx.gasprice` in the transaction, so we hardcode
+            // its value here.
             executorPayment = (1000000 * gasUsed * (100 + executorPaymentPercentage)) / 100;
         } else {
-            // Optimism goerli does not have the basefee opcode, so we hardcode its value here.
+            // Optimism mainnet does not include `tx.gasprice` in the transaction, so we hardcode
+            // its value here.
             executorPayment = (gasUsed * (100 + executorPaymentPercentage)) / 100;
         }
 
@@ -708,13 +710,15 @@ contract ChugSplashManager is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         // Calculate the executor's payment.
         uint256 executorPayment;
         if (block.chainid != 10 && block.chainid != 420) {
-            // Use the basefee for any network that isn't Optimism.
-            executorPayment = (block.basefee * gasUsed * (100 + executorPaymentPercentage)) / 100;
+            // Use the gas price for any network that isn't Optimism.
+            executorPayment = (tx.gasprice * gasUsed * (100 + executorPaymentPercentage)) / 100;
         } else if (block.chainid == 10) {
-            // Optimism mainnet does not have the basefee opcode, so we hardcode its value here.
+            // Optimism mainnet does not include `tx.gasprice` in the transaction, so we hardcode
+            // its value here.
             executorPayment = (1000000 * gasUsed * (100 + executorPaymentPercentage)) / 100;
         } else {
-            // Optimism goerli does not have the basefee opcode, so we hardcode its value here.
+            // Optimism mainnet does not include `tx.gasprice` in the transaction, so we hardcode
+            // its value here.
             executorPayment = (gasUsed * (100 + executorPaymentPercentage)) / 100;
         }
 

--- a/packages/contracts/src/ifaces.ts
+++ b/packages/contracts/src/ifaces.ts
@@ -8,7 +8,7 @@ export const DefaultAdapterArtifact = require('../artifacts/contracts/adapters/D
 export const ProxyArtifact = require('../artifacts/contracts/libraries/Proxy.sol/Proxy.json')
 export const ProxyInitializerArtifact = require('../artifacts/contracts/ProxyInitializer.sol/ProxyInitializer.json')
 
-export const buildInfo = require('../artifacts/build-info/0d07ba6058c55798a6fa4cbe1691d495.json')
+export const buildInfo = require('../artifacts/build-info/f97f29c9a27f659788545814a47f2c4e.json')
 
 export const ChugSplashRegistryABI = ChugSplashRegistryArtifact.abi
 export const ChugSplashBootLoaderABI = ChugSplashBootLoaderArtifact.abi


### PR DESCRIPTION
This ensures that the executor cannot lose money on a deployment, which was previously possible if a sizable `maxPriorityFeePerGas` was used.