### PR TITLE
feat(exec): Support defining executor port with environment variable

### DIFF
--- a/.changeset/tough-ladybugs-appear.md
+++ b/.changeset/tough-ladybugs-appear.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/executor': patch
+---
+
+Support defining executor port with environment variable

--- a/packages/executor/.env.example
+++ b/packages/executor/.env.example
@@ -7,3 +7,4 @@ IPFS_PROJECT_ID=<ipfs project id to retrieve config file>
 IPFS_API_KEY_SECRET=<ipfs api key to retrieve config file>
 ETHERSCAN_API_KEY=<Etherscan API key>
 HARDHAT_NETWORK=<Target hardhat network, used for verification>
+EXECUTOR_PORT=7300

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -63,6 +63,7 @@ export class ChugSplashExecutor extends BaseServiceV2<Options, Metrics, State> {
       version: require('../package.json').version,
       loop: true,
       loopIntervalMs: 5000,
+      port: parseInt(process.env.EXECUTOR_PORT, 10),
       options,
       optionsSpec: {
         url: {


### PR DESCRIPTION
## Purpose
Adds support for defining the executor's port with an environment variable. This is needed because the ports must be different when deploying multiple containers on AWS.