### PR TITLE
fix(core): use EIP-1559 transactions if supported by the network

### DIFF
--- a/.changeset/selfish-badgers-buy.md
+++ b/.changeset/selfish-badgers-buy.md
@@ -1,0 +1,7 @@
+---
+'@chugsplash/core': patch
+'@chugsplash/executor': patch
+'@chugsplash/plugins': patch
+---
+
+Override transaction gas prices to use EIP-1559 if supported by the network

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -21,6 +21,7 @@ import {
   getAmountToDeposit,
   isContractDeployed,
   formatEther,
+  getGasPriceOverrides,
 } from '@chugsplash/core'
 import { getChainId } from '@eth-optimism/core-utils'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
@@ -429,7 +430,8 @@ reference name to something other than ${upgradeReferenceName}.`
     await ChugSplashManager.proposeChugSplashBundle(
       bundle.root,
       bundle.actions.length,
-      configUri
+      configUri,
+      await getGasPriceOverrides(provider)
     )
   ).wait()
 


### PR DESCRIPTION
This PR changes all transactions to use EIP-1559 gas pricing mechanisms as long as the network supports it. This prevents transactions from stalling on Goerli, which was a common occurrence since EIP 1559 transactions were not being used by default on it.