### PR TITLE
fix(pg): remove logic that initialize chugsplash when starting hardhat node

### DIFF
--- a/.changeset/wet-ads-juggle.md
+++ b/.changeset/wet-ads-juggle.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/plugins': patch
+---
+
+Remove unnecessary logic that initializes ChugSplash when starting a Hardhat node

--- a/packages/plugins/src/hardhat/tasks.ts
+++ b/packages/plugins/src/hardhat/tasks.ts
@@ -1048,17 +1048,12 @@ task(TASK_CHUGSPLASH_FUND)
 
 task(TASK_NODE)
   .addFlag('deployAll', 'Deploy all ChugSplash config files on startup')
-  .addFlag(
-    'disableChugsplash',
-    "Completely disable all of ChugSplash's activity."
-  )
   .addFlag('hide', "Hide all of ChugSplash's output")
   .addFlag('noCompile', "Don't compile when running this task")
   .setAction(
     async (
       args: {
         deployAll: boolean
-        disableChugsplash: boolean
         hide: boolean
         noCompile: boolean
         confirm: boolean
@@ -1066,9 +1061,9 @@ task(TASK_NODE)
       hre: HardhatRuntimeEnvironment,
       runSuper
     ) => {
-      const { deployAll, disableChugsplash, hide, noCompile } = args
+      const { deployAll, hide, noCompile } = args
 
-      if (!disableChugsplash) {
+      if (deployAll) {
         const spinner = ora({ isSilent: hide })
         spinner.start('Booting up ChugSplash...')
 
@@ -1079,15 +1074,13 @@ task(TASK_NODE)
 
         spinner.succeed('ChugSplash has been initialized.')
 
-        if (deployAll) {
-          if (!noCompile) {
-            await hre.run(TASK_COMPILE, {
-              quiet: true,
-            })
-          }
-          await deployAllChugSplashConfigs(hre, hide, '', true, true, spinner)
-          await writeHardhatSnapshotId(hre, 'localhost')
+        if (!noCompile) {
+          await hre.run(TASK_COMPILE, {
+            quiet: true,
+          })
         }
+        await deployAllChugSplashConfigs(hre, hide, '', true, true, spinner)
+        await writeHardhatSnapshotId(hre, 'localhost')
       }
       await runSuper(args)
     }


### PR DESCRIPTION
This logic is redundant because `initializeChugSplash` is called from the in-process executor.