### PR TITLE
fix(ex): detect old approval events

### DIFF
--- a/.changeset/afraid-tables-itch.md
+++ b/.changeset/afraid-tables-itch.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/executor': patch
+---
+
+Fix bug where executor wasn't detecting old approvals

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -125,7 +125,7 @@ export class ChugSplashExecutor extends BaseServiceV2<Options, Metrics, State> {
       ChugSplashRegistryABI,
       this.state.provider
     )
-    this.state.lastBlockNumber = -1
+    this.state.lastBlockNumber = 0
 
     // This represents a queue of "BundleApproved" events to execute.
     this.state.eventsQueue = []


### PR DESCRIPTION
The executor wasn't detecting old BundleApproved events on startup because `lastBlockNumber` was set to -1 instead of 0.