### PR TITLE
fix(core): use `getNetwork` to retrieve network name

### DIFF
--- a/.changeset/rich-elephants-exercise.md
+++ b/.changeset/rich-elephants-exercise.md
@@ -1,0 +1,6 @@
+---
+'@chugsplash/core': patch
+'@chugsplash/plugins': patch
+---
+
+Use `getNetwork` to retrieve network name

--- a/packages/core/src/actions/deployments.ts
+++ b/packages/core/src/actions/deployments.ts
@@ -124,7 +124,7 @@ export const proposeChugSplashBundle = async (
     )
   ).wait()
 
-  const networkName = resolveNetworkName(provider, integration)
+  const networkName = await resolveNetworkName(provider, integration)
   await trackProposed(
     await getProjectOwnerAddress(signer, projectName),
     projectName,

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -46,7 +46,7 @@ export const monitorExecution = async (
   integration: Integration
 ) => {
   spinner.start('Waiting for executor...')
-  const networkName = resolveNetworkName(provider, integration)
+  const networkName = await resolveNetworkName(provider, integration)
 
   const projectName = parsedConfig.options.projectName
   const ChugSplashManager = getChugSplashManager(signer, projectName)

--- a/packages/core/src/messages/index.ts
+++ b/packages/core/src/messages/index.ts
@@ -2,26 +2,27 @@ import { BigNumber, ethers } from 'ethers'
 
 import { Integration } from '../constants'
 
-export const resolveNetworkName = (
-  provider: ethers.providers.JsonRpcProvider,
+export const resolveNetworkName = async (
+  provider: ethers.providers.Provider,
   integration: Integration
 ) => {
-  if (provider.network.name === 'unknown') {
+  const { name: networkName } = await provider.getNetwork()
+  if (networkName === 'unknown') {
     if (integration === 'hardhat') {
       return 'hardhat'
     } else if (integration === 'foundry') {
       return 'anvil'
     }
   }
-  return provider.network.name
+  return networkName
 }
 
-export const errorProjectNotRegistered = (
+export const errorProjectNotRegistered = async (
   provider: ethers.providers.JsonRpcProvider,
   configPath: string,
   integration: Integration
 ) => {
-  const networkName = resolveNetworkName(provider, integration)
+  const networkName = await resolveNetworkName(provider, integration)
 
   if (integration === 'hardhat') {
     throw new Error(`This project has not been registered on ${networkName}.
@@ -38,12 +39,12 @@ TODO: Finish foundry error message`)
   }
 }
 
-export const errorProjectCurrentlyActive = (
+export const errorProjectCurrentlyActive = async (
   provider: ethers.providers.JsonRpcProvider,
   integration: Integration,
   configPath: string
 ) => {
-  const networkName = resolveNetworkName(provider, integration)
+  const networkName = await resolveNetworkName(provider, integration)
 
   if (integration === 'hardhat') {
     throw new Error(
@@ -60,13 +61,13 @@ TODO: Finish foundry error message`)
   }
 }
 
-export const successfulProposalMessage = (
+export const successfulProposalMessage = async (
   provider: ethers.providers.JsonRpcProvider,
   amount: BigNumber,
   configPath: string,
   integration: Integration
-): string => {
-  const networkName = resolveNetworkName(provider, integration)
+): Promise<string> => {
+  const networkName = await resolveNetworkName(provider, integration)
 
   if (integration === 'hardhat') {
     if (amount.gt(0)) {
@@ -92,13 +93,13 @@ TODO: Finish foundry success message`
   }
 }
 
-export const alreadyProposedMessage = (
+export const alreadyProposedMessage = async (
   provider: ethers.providers.JsonRpcProvider,
   amount: BigNumber,
   configPath: string,
   integration: Integration
-): string => {
-  const networkName = resolveNetworkName(provider, integration)
+): Promise<string> => {
+  const networkName = await resolveNetworkName(provider, integration)
 
   if (integration === 'hardhat') {
     if (amount.gt(0)) {

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -89,7 +89,7 @@ export const chugsplashRegisterAbstractTask = async (
       owner
     )
 
-    const networkName = resolveNetworkName(provider, integration)
+    const networkName = await resolveNetworkName(provider, integration)
 
     const projectName = parsedConfig.options.projectName
     await trackRegistered(
@@ -145,7 +145,7 @@ export const chugsplashProposeAbstractTask = async (
     (await isProjectRegistered(signer, parsedConfig.options.projectName)) ===
     false
   ) {
-    errorProjectNotRegistered(provider, configPath, integration)
+    await errorProjectNotRegistered(provider, configPath, integration)
   }
 
   const ChugSplashManager = getChugSplashManager(
@@ -227,7 +227,7 @@ with a name other than ${parsedConfig.options.projectName}`
         silent,
         integration
       )
-      const message = successfulProposalMessage(
+      const message = await successfulProposalMessage(
         provider,
         amountToDeposit,
         configPath,
@@ -237,7 +237,7 @@ with a name other than ${parsedConfig.options.projectName}`
     } else {
       // Bundle was already in the `PROPOSED` state before the call to this task.
       spinner.fail(
-        alreadyProposedMessage(
+        await alreadyProposedMessage(
           provider,
           amountToDeposit,
           configPath,
@@ -377,7 +377,7 @@ IPFS_API_KEY_SECRET: ...
   }
 
   if (spinner) {
-    const networkName = resolveNetworkName(provider, integration)
+    const networkName = await resolveNetworkName(provider, integration)
     commitToIpfs
       ? spinner.succeed(
           `${parsedConfig.options.projectName} has been committed to IPFS.`
@@ -411,7 +411,7 @@ export const chugsplashApproveAbstractTask = async (
     artifactPaths,
     integration
   )
-  const networkName = resolveNetworkName(provider, integration)
+  const networkName = await resolveNetworkName(provider, integration)
 
   const spinner = ora({ isSilent: silent, stream })
   spinner.start(
@@ -422,7 +422,7 @@ export const chugsplashApproveAbstractTask = async (
   const signerAddress = await signer.getAddress()
 
   if (!(await isProjectRegistered(signer, projectName))) {
-    errorProjectNotRegistered(provider, configPath, 'hardhat')
+    await errorProjectNotRegistered(provider, configPath, 'hardhat')
   }
 
   const projectOwnerAddress = await getProjectOwnerAddress(signer, projectName)
@@ -559,7 +559,7 @@ export const chugsplashFundAbstractTask = async (
   const projectName = parsedConfig.options.projectName
   const chugsplashManagerAddress = getChugSplashManagerProxyAddress(projectName)
   const signerBalance = await signer.getBalance()
-  const networkName = resolveNetworkName(provider, integration)
+  const networkName = await resolveNetworkName(provider, integration)
 
   if (signerBalance.lt(amount)) {
     throw new Error(`Signer's balance is less than the amount required to fund your project.
@@ -571,7 +571,7 @@ Please send more ETH to ${await signer.getAddress()} on ${networkName} then try 
   }
 
   if (!(await isProjectRegistered(signer, projectName))) {
-    errorProjectNotRegistered(provider, configPath, 'hardhat')
+    await errorProjectNotRegistered(provider, configPath, 'hardhat')
   }
 
   spinner.start(
@@ -620,7 +620,7 @@ export const chugsplashDeployAbstractTask = async (
   stream: NodeJS.WritableStream = process.stderr
 ): Promise<FoundryContractArtifact[] | undefined> => {
   const spinner = ora({ isSilent: silent, stream })
-  const networkName = resolveNetworkName(provider, integration)
+  const networkName = await resolveNetworkName(provider, integration)
 
   if (executor === undefined && !remoteExecution) {
     throw new Error(
@@ -879,7 +879,7 @@ export const chugsplashMonitorAbstractTask = async (
   remoteExecution: boolean,
   stream: NodeJS.WritableStream = process.stderr
 ) => {
-  const networkName = resolveNetworkName(provider, 'hardhat')
+  const networkName = await resolveNetworkName(provider, 'hardhat')
   const spinner = ora({ isSilent: silent, stream })
   spinner.start(`Loading project information...`)
 
@@ -897,7 +897,7 @@ export const chugsplashMonitorAbstractTask = async (
     (await isProjectRegistered(signer, parsedConfig.options.projectName)) ===
     false
   ) {
-    errorProjectNotRegistered(provider, configPath, 'hardhat')
+    await errorProjectNotRegistered(provider, configPath, 'hardhat')
   }
 
   // Get the bundle info by calling the commit subtask locally (i.e. without publishing the
@@ -985,7 +985,7 @@ export const chugsplashCancelAbstractTask = async (
   integration: Integration,
   stream: NodeJS.WritableStream = process.stderr
 ) => {
-  const networkName = resolveNetworkName(provider, integration)
+  const networkName = await resolveNetworkName(provider, integration)
 
   const parsedConfig = readParsedChugSplashConfig(
     configPath,
@@ -998,7 +998,7 @@ export const chugsplashCancelAbstractTask = async (
   spinner.start(`Cancelling ${projectName} on ${networkName}.`)
 
   if (!(await isProjectRegistered(signer, projectName))) {
-    errorProjectNotRegistered(provider, configPath, 'hardhat')
+    await errorProjectNotRegistered(provider, configPath, 'hardhat')
   }
 
   const projectOwnerAddress = await getProjectOwnerAddress(signer, projectName)
@@ -1061,7 +1061,7 @@ export const chugsplashWithdrawAbstractTask = async (
   integration: Integration,
   stream: NodeJS.WritableStream = process.stderr
 ) => {
-  const networkName = resolveNetworkName(provider, integration)
+  const networkName = await resolveNetworkName(provider, integration)
   const parsedConfig = readParsedChugSplashConfig(
     configPath,
     artifactPaths,
@@ -1075,7 +1075,7 @@ export const chugsplashWithdrawAbstractTask = async (
   )
 
   if (!(await isProjectRegistered(signer, projectName))) {
-    errorProjectNotRegistered(provider, configPath, 'hardhat')
+    await errorProjectNotRegistered(provider, configPath, 'hardhat')
   }
 
   const projectOwnerAddress = await getProjectOwnerAddress(signer, projectName)
@@ -1106,7 +1106,7 @@ Caller attempted to claim funds using the address: ${await signer.getAddress()}`
   )
 
   if (bundleState.status === ChugSplashBundleStatus.APPROVED) {
-    errorProjectCurrentlyActive(provider, integration, configPath)
+    await errorProjectCurrentlyActive(provider, integration, configPath)
   }
 
   const amountToWithdraw = await getOwnerWithdrawableAmount(
@@ -1146,7 +1146,7 @@ export const chugsplashListProjectsAbstractTask = async (
   integration: Integration,
   stream: NodeJS.WritableStream = process.stderr
 ) => {
-  const networkName = resolveNetworkName(provider, integration)
+  const networkName = await resolveNetworkName(provider, integration)
   const signerAddress = await signer.getAddress()
 
   const spinner = ora({ stream })
@@ -1232,7 +1232,7 @@ export const chugsplashListProposersAbstractTask = async (
     (await isProjectRegistered(signer, parsedConfig.options.projectName)) ===
     false
   ) {
-    errorProjectNotRegistered(provider, configPath, 'hardhat')
+    await errorProjectNotRegistered(provider, configPath, 'hardhat')
   }
 
   const ChugSplashManager = getChugSplashManager(
@@ -1269,7 +1269,7 @@ export const chugsplashListProposersAbstractTask = async (
     }
   }
 
-  const networkName = resolveNetworkName(provider, integration)
+  const networkName = await resolveNetworkName(provider, integration)
   const projectName = parsedConfig.options.projectName
   await trackListProposers(
     await getProjectOwnerAddress(signer, projectName),
@@ -1308,7 +1308,7 @@ export const chugsplashAddProposersAbstractTask = async (
     (await isProjectRegistered(signer, parsedConfig.options.projectName)) ===
     false
   ) {
-    errorProjectNotRegistered(provider, configPath, 'hardhat')
+    await errorProjectNotRegistered(provider, configPath, 'hardhat')
   }
 
   const ChugSplashManager = getChugSplashManager(
@@ -1328,7 +1328,7 @@ export const chugsplashAddProposersAbstractTask = async (
 
   spinner.succeed('Project ownership confirmed.')
 
-  const networkName = resolveNetworkName(provider, integration)
+  const networkName = await resolveNetworkName(provider, integration)
   const projectName = parsedConfig.options.projectName
   await trackAddProposers(
     await getProjectOwnerAddress(signer, projectName),
@@ -1390,7 +1390,7 @@ export const chugsplashClaimProxyAbstractTask = async (
     (await isProjectRegistered(signer, parsedConfig.options.projectName)) ===
     false
   ) {
-    errorProjectNotRegistered(provider, configPath, 'hardhat')
+    await errorProjectNotRegistered(provider, configPath, 'hardhat')
   }
 
   const owner = await getProjectOwnerAddress(
@@ -1426,7 +1426,7 @@ export const chugsplashClaimProxyAbstractTask = async (
     )
   ).wait()
 
-  const networkName = resolveNetworkName(provider, integration)
+  const networkName = await resolveNetworkName(provider, integration)
   const projectName = parsedConfig.options.projectName
   await trackClaimProxy(
     await getProjectOwnerAddress(signer, projectName),
@@ -1462,7 +1462,7 @@ export const chugsplashTransferOwnershipAbstractTask = async (
     (await isProjectRegistered(signer, parsedConfig.options.projectName)) ===
     false
   ) {
-    errorProjectNotRegistered(provider, configPath, 'hardhat')
+    await errorProjectNotRegistered(provider, configPath, 'hardhat')
   }
 
   spinner.succeed('Project registration detected')
@@ -1532,7 +1532,7 @@ export const chugsplashTransferOwnershipAbstractTask = async (
     )
   ).wait()
 
-  const networkName = resolveNetworkName(provider, integration)
+  const networkName = await resolveNetworkName(provider, integration)
   const projectName = parsedConfig.options.projectName
   await trackTransferProxy(
     await getProjectOwnerAddress(signer, projectName),

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -146,7 +146,10 @@ ${configsWithFileNames.map(
 export const resetChugSplashDeployments = async (
   hre: HardhatRuntimeEnvironment
 ) => {
-  const networkFolderName = resolveNetworkName(hre.ethers.provider, 'hardhat')
+  const networkFolderName = await resolveNetworkName(
+    hre.ethers.provider,
+    'hardhat'
+  )
   const snapshotIdPath = path.join(
     path.basename(hre.config.paths.deployments),
     networkFolderName,

--- a/packages/plugins/src/hardhat/tasks.ts
+++ b/packages/plugins/src/hardhat/tasks.ts
@@ -730,7 +730,10 @@ task(TASK_NODE)
             })
           }
           await deployAllChugSplashConfigs(hre, hide, '', true, true)
-          const networkName = resolveNetworkName(hre.ethers.provider, 'hardhat')
+          const networkName = await resolveNetworkName(
+            hre.ethers.provider,
+            'hardhat'
+          )
           await writeSnapshotId(
             hre.ethers.provider,
             networkName,
@@ -778,7 +781,10 @@ task(TASK_TEST)
           }
           await deployAllChugSplashConfigs(hre, !show, '', true, true)
         } finally {
-          const networkName = resolveNetworkName(hre.ethers.provider, 'hardhat')
+          const networkName = await resolveNetworkName(
+            hre.ethers.provider,
+            'hardhat'
+          )
           await writeSnapshotId(
             hre.ethers.provider,
             networkName,


### PR DESCRIPTION
Previously, `npx hardhat test` was failing in the demo package due to an error that was caused by calling `hre.ethers.provider.network.name`. I'm not 100% sure about the cause of this, but it seems to be stemming from the '@nomiclabs/hardhat-ethers` package.