### PR TITLE
fix(core): Ensure array.at() is always supported

### DIFF
--- a/.changeset/mean-mirrors-chew.md
+++ b/.changeset/mean-mirrors-chew.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Ensure Array.at() is always supported

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -32,6 +32,7 @@ import { ChugSplashActionBundle, ChugSplashActionType } from './actions'
 import { FoundryContractArtifact } from './types'
 import { ArtifactPaths } from './languages'
 import { Integration } from './constants'
+import 'core-js/features/array/at'
 
 export const computeBundleId = (
   bundleRoot: string,


### PR DESCRIPTION
## Purpose
Fixes an issue where Array.at() is not always supported depending on the NodeJS version due to how new the function standard is. This PR ensures that the function is polyfilled, so that it can be used regardless of the environment. 