### PR TITLE
fix(core): don't infer network name in error messages

### DIFF
--- a/.changeset/afraid-eels-repair.md
+++ b/.changeset/afraid-eels-repair.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Change error messages so that they don't infer network name

--- a/packages/core/src/actions/deployments.ts
+++ b/packages/core/src/actions/deployments.ts
@@ -61,12 +61,7 @@ export const proposeChugSplashBundle = async (
   const upgradeReferenceName = await checkIsUpgrade(provider, parsedConfig)
   if (upgradeReferenceName) {
     // Check if upgrade is valid
-    await checkValidUpgrade(
-      provider,
-      parsedConfig,
-      configPath,
-      await resolveNetworkName(provider, integration)
-    )
+    await checkValidUpgrade(provider, parsedConfig, configPath)
 
     spinner.succeed(`${projectName} is an upgrade.`)
 

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -14,7 +14,6 @@ import { EXECUTION_BUFFER_MULTIPLIER, Integration } from '../constants'
 import { getFinalDeploymentTxnHash } from '../deployments'
 import { getAmountToDeposit, getOwnerWithdrawableAmount } from '../fund'
 import { ArtifactPaths } from '../languages'
-import { resolveNetworkName } from '../messages'
 import {
   formatEther,
   getChugSplashManager,
@@ -42,12 +41,9 @@ export const monitorExecution = async (
   parsedConfig: ParsedChugSplashConfig,
   bundle: ChugSplashActionBundle,
   bundleId: string,
-  spinner: ora.Ora,
-  integration: Integration
+  spinner: ora.Ora
 ) => {
   spinner.start('Waiting for executor...')
-  const networkName = await resolveNetworkName(provider, integration)
-
   const projectName = parsedConfig.options.projectName
   const ChugSplashManager = getChugSplashManager(signer, projectName)
 
@@ -74,9 +70,9 @@ export const monitorExecution = async (
         `${projectName} has insufficient funds to complete the deployment. Please report this error to improve our deployment cost estimation.
   Run the following command to add funds to your deployment so it can be completed:
 
-  npx hardhat chugsplash-fund --network ${networkName} --amount ${amountToDeposit.mul(
-          EXECUTION_BUFFER_MULTIPLIER
-        )} --config-path <configPath>
+  npx hardhat chugsplash-fund --network <network> --amount ${amountToDeposit.mul(
+    EXECUTION_BUFFER_MULTIPLIER
+  )} --config-path <configPath>
           `
       )
     }

--- a/packages/core/src/messages/index.ts
+++ b/packages/core/src/messages/index.ts
@@ -28,7 +28,7 @@ export const errorProjectNotRegistered = async (
     throw new Error(`This project has not been registered on ${networkName}.
 To register the project on this network, run the following command:
 
-npx hardhat chugsplash-register --network ${networkName} --owner <ownerAddress> --config-path ${configPath}
+npx hardhat chugsplash-register --network <network> --owner <ownerAddress> --config-path ${configPath}
   `)
   } else {
     // TODO - output foundry error
@@ -39,18 +39,15 @@ TODO: Finish foundry error message`)
   }
 }
 
-export const errorProjectCurrentlyActive = async (
-  provider: ethers.providers.JsonRpcProvider,
+export const errorProjectCurrentlyActive = (
   integration: Integration,
   configPath: string
 ) => {
-  const networkName = await resolveNetworkName(provider, integration)
-
   if (integration === 'hardhat') {
     throw new Error(
       `Project is currently active. You must cancel the project in order to withdraw funds:
 
-npx hardhat chugsplash-cancel --network ${networkName} --config-path ${configPath}
+npx hardhat chugsplash-cancel --network <network> --config-path ${configPath}
         `
     )
   } else {
@@ -73,11 +70,11 @@ export const successfulProposalMessage = async (
     if (amount.gt(0)) {
       return `Project successfully proposed on ${networkName}. Fund and approve the deployment using the command:
 
-npx hardhat chugsplash-approve --network ${networkName} --amount ${amount} --config-path ${configPath}`
+npx hardhat chugsplash-approve --network <network> --amount ${amount} --config-path ${configPath}`
     } else {
       return `Project successfully proposed and funded on ${networkName}. Approve the deployment using the command:
 
-npx hardhat chugsplash-approve --network ${networkName} --config-path ${configPath}`
+npx hardhat chugsplash-approve --network <network> --config-path ${configPath}`
     }
   } else {
     // TODO - output foundry error
@@ -105,11 +102,11 @@ export const alreadyProposedMessage = async (
     if (amount.gt(0)) {
       return `Project has already been proposed on ${networkName}. Fund and approve the deployment using the command:
 
-npx hardhat chugsplash-approve --network ${networkName} --amount ${amount} --config-path ${configPath}`
+npx hardhat chugsplash-approve --network <network> --amount ${amount} --config-path ${configPath}`
     } else {
       return `Project has already been proposed and funded on ${networkName}. Approve the deployment using the command:
 
-npx hardhat chugsplash-approve --network ${networkName} --config-path ${configPath}`
+npx hardhat chugsplash-approve --network <network> --config-path ${configPath}`
     }
   } else {
     // TODO - output foundry error

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -460,12 +460,12 @@ Owner's address: ${projectOwnerAddress}`)
     throw new Error(`You must first propose the project before it can be approved.
 To propose the project, run the command:
 
-npx hardhat chugsplash-propose --network ${networkName} --config-path ${configPath}`)
+npx hardhat chugsplash-propose --network <network> --config-path ${configPath}`)
   } else if (bundleState.status === ChugSplashBundleStatus.APPROVED) {
     spinner.succeed(`Project has already been approved. It should be executed shortly.
 Run the following command to monitor its status:
 
-npx hardhat chugsplash-monitor --network ${networkName} --config-path ${configPath}`)
+npx hardhat chugsplash-monitor --network <network> --config-path ${configPath}`)
   } else if (bundleState.status === ChugSplashBundleStatus.COMPLETED) {
     spinner.succeed(`Project was already completed on ${networkName}.`)
   } else if (bundleState.status === ChugSplashBundleStatus.CANCELLED) {
@@ -487,7 +487,7 @@ Please wait a couple minutes then try again.`
     if (amountToDeposit.gt(0)) {
       throw new Error(`Project was not approved because it has insufficient funds.
 Fund the project with the following command:
-npx hardhat chugsplash-fund --network ${networkName} --amount ${amountToDeposit.mul(
+npx hardhat chugsplash-fund --network <network> --amount ${amountToDeposit.mul(
         EXECUTION_BUFFER_MULTIPLIER
       )} --config-path <configPath>`)
     }
@@ -517,8 +517,7 @@ npx hardhat chugsplash-fund --network ${networkName} --amount ${amountToDeposit.
         parsedConfig,
         bundle,
         bundleId,
-        spinner,
-        integration
+        spinner
       )
       await postExecutionActions(
         provider,
@@ -809,8 +808,7 @@ export const chugsplashDeployAbstractTask = async (
       parsedConfig,
       bundle,
       bundleId,
-      spinner,
-      integration
+      spinner
     )
   } else if (executor !== undefined) {
     spinner.start(`Executing ${projectName}...`)
@@ -952,8 +950,7 @@ project with a name other than ${parsedConfig.options.projectName}`
     parsedConfig,
     bundle,
     bundleId,
-    spinner,
-    'hardhat'
+    spinner
   )
 
   await postExecutionActions(
@@ -1113,7 +1110,7 @@ Caller attempted to claim funds using the address: ${await signer.getAddress()}`
   )
 
   if (bundleState.status === ChugSplashBundleStatus.APPROVED) {
-    await errorProjectCurrentlyActive(provider, integration, configPath)
+    errorProjectCurrentlyActive(integration, configPath)
   }
 
   const amountToWithdraw = await getOwnerWithdrawableAmount(

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -132,8 +132,7 @@ export const checkIsUpgrade = async (
 export const checkValidUpgrade = async (
   provider: ethers.providers.Provider,
   parsedConfig: ParsedChugSplashConfig,
-  configPath: string,
-  networkName: string
+  configPath: string
 ) => {
   const requiresOwnershipTransfer: {
     name: string
@@ -170,7 +169,7 @@ export const checkValidUpgrade = async (
       `Error: No deployed contracts were detected for project ${parsedConfig.options.projectName}.
 
 Run the following command to deploy this project for the first time:
-npx hardhat chugsplash-deploy --network ${networkName} --config-path ${configPath}
+npx hardhat chugsplash-deploy --network <network> --config-path ${configPath}
       `
     )
   }
@@ -183,7 +182,7 @@ npx hardhat chugsplash-deploy --network ${networkName} --config-path ${configPat
       )}
 
 To upgrade these contracts, you must first transfer ownership of them to ChugSplash using the following command:
-npx hardhat chugsplash-transfer-ownership --network ${networkName} --config-path ${configPath} --proxy <proxy address>
+npx hardhat chugsplash-transfer-ownership --network <network> --config-path ${configPath} --proxy <proxy address>
       `
     )
   }


### PR DESCRIPTION
Now that we use `resolveNetworkName`, the `localhost` network is now `hardhat`, which makes the network name in error messages confusing.