### PR TITLE
fix(core): minor tweak to config error string

### DIFF
--- a/.changeset/angry-penguins-chew.md
+++ b/.changeset/angry-penguins-chew.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Minor improvement to config error string.

--- a/packages/core/src/languages/solidity/storage.ts
+++ b/packages/core/src/languages/solidity/storage.ts
@@ -508,8 +508,9 @@ export const computeStorageSlots = (
       storageEntries[storageObj.label] = storageObj
     } else {
       throw new Error(
-        `Could not find variable "${storageObj.label}" in ${contractConfig.contract}.
-Did you forget to declare it in your ChugSplash config file?`
+        `Could not find variable "${storageObj.label}" from the contract "${contractConfig.contract}" in your ChugSplash config file.\n` +
+          `You must configure all variables that are defined in the contract.\n` +
+          `Did you forget to declare it in your ChugSplash config file?`
       )
     }
   }


### PR DESCRIPTION
Small improvement to the config error when didn't provide a definition for every variable in a contract. Was unclear if the message was referring to a variable that was in the contract but not in the config or if the variable was in the config but not in the contract.