### PR TITLE
immutable bug demo

### DIFF
--- a/packages/demo/contracts/HelloChugSplash.sol
+++ b/packages/demo/contracts/HelloChugSplash.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.15;
 
 contract HelloChugSplash {
-    uint8 public number;
+    uint8 public immutable number = 123;
     bool public stored;
     address public otherStorage;
     string public storageName;


### PR DESCRIPTION
If a user assigns a value to an immutable variable in a contract, and also assigns a value to it in their ChugSplash file, the value in the ChugSplash file will be ignored. This is obviously unexpected behavior. In this case, an error should be thrown telling the user that they should either remove the variable assignment in their ChugSplash file, or remove the variable assignment in their contract.

To demonstrate this, go to the demo package and run:
`npx hardhat test`