### PR TITLE
fix(exec): Add default port for executor

### DIFF
--- a/.changeset/chilled-ads-protect.md
+++ b/.changeset/chilled-ads-protect.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/executor': patch
+---
+
+Set executor default port

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -53,7 +53,7 @@ export class ChugSplashExecutor extends BaseServiceV2<
       loop: true,
       options: {
         loopIntervalMs: 5000,
-        port: parseInt(process.env.EXECUTOR_PORT, 10),
+        port: parseInt(process.env.EXECUTOR_PORT ?? '7300', 10),
         ...options,
       },
       optionsSpec: {


### PR DESCRIPTION
## Purpose
Adds a default port for the executor which eliminates the need to define an `EXECUTOR_PORT` environment variable.