### PR TITLE
fix(core): Throw error if immutable variable value is defined in both the contract and config file

### DIFF
--- a/.changeset/fresh-hotels-warn.md
+++ b/.changeset/fresh-hotels-warn.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Throw an error if immutable variable value is defined in both the contract and config file

--- a/packages/core/src/actions/bundle.ts
+++ b/packages/core/src/actions/bundle.ts
@@ -254,7 +254,8 @@ export const bundleLocal = async (
     const immutableVariables = getImmutableVariables(
       compilerOutput,
       sourceName,
-      contractName
+      contractName,
+      parsedConfig.contracts[referenceName]
     )
     artifacts[referenceName] = {
       creationCode,

--- a/packages/core/src/languages/solidity/compiler.ts
+++ b/packages/core/src/languages/solidity/compiler.ts
@@ -122,7 +122,8 @@ export const getCanonicalConfigArtifacts = async (
         const immutableVariables = getImmutableVariables(
           compilerOutput,
           sourceName,
-          contractName
+          contractName,
+          canonicalConfig.contracts[referenceName]
         )
 
         addEnumMembersToStorageLayout(

--- a/packages/core/src/languages/solidity/storage.ts
+++ b/packages/core/src/languages/solidity/storage.ts
@@ -600,6 +600,11 @@ export const addEnumMembersToStorageLayout = (
   contractName: string,
   sourceNodes: any
 ): SolidityStorageLayout => {
+  // If no vars are defined or all vars are immutable, then storageLayout.types will be null and we can just return
+  if (storageLayout.types === null) {
+    return storageLayout
+  }
+
   for (const layoutType of Object.values(storageLayout.types)) {
     if (layoutType.label.startsWith('enum')) {
       const canonicalVarName = layoutType.label.substring(5)


### PR DESCRIPTION
## Purpose
Fixes an issue where defining the value of an immutable variable in both the contract and config file could lead to unanticipated results. 