### PR TITLE
fix(core): Add additional recommendation to clear contract artifact cache if var not found in storage layout

### DIFF
--- a/.changeset/short-mangos-listen.md
+++ b/.changeset/short-mangos-listen.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Add recommendation to clear contract artifacts if variable not found in storage layout

--- a/packages/core/src/languages/solidity/storage.ts
+++ b/packages/core/src/languages/solidity/storage.ts
@@ -510,7 +510,8 @@ export const computeStorageSlots = (
       throw new Error(
         `Could not find variable "${storageObj.label}" from the contract "${contractConfig.contract}" in your ChugSplash config file.\n` +
           `You must configure all variables that are defined in the contract.\n` +
-          `Did you forget to declare it in your ChugSplash config file?`
+          `Did you forget to declare it in your ChugSplash config file?` +
+          `You may also need to delete and regenerate your contract compilation artifacts.`
       )
     }
   }
@@ -530,7 +531,7 @@ export const computeStorageSlots = (
     if (!storageObj) {
       throw new Error(
         `variable "${variableName}" was defined in the ChugSplash config for ${contractConfig.contract}
-but does not exist as a variable in the contract`
+but does not exist as a variable in the contract. If you think this is a mistake, you may need to delete and regenerate your contract compilation artifacts.`
       )
     }
 


### PR DESCRIPTION
## Purpose
Adds an additional recommendation to clear your contract compilation artifact cache if a variable is included in the ChugSplash config, but not found in the contract storage layout. 

I encountered an issue where my deployment of the optimism repo failed b/c old contract artifacts were cached and for some reason, hardhat failed to detect that they needed to be recompiled. The solution was to remove the old artifacts and recompile. 