### PR TITLE
Bump Core Dependency Versions

### DIFF
--- a/.changeset/lucky-steaks-run.md
+++ b/.changeset/lucky-steaks-run.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Bump @eth-optimism-commonts dependency version


### PR DESCRIPTION
## Purpose
A new release was not pushed for the core package because I did not include a changeset. 