### PR TITLE
fix(core): move the 'missing storage layout error' from `getStorageLayout` to `getBuildInfo`

### DIFF
--- a/.changeset/orange-pants-double.md
+++ b/.changeset/orange-pants-double.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Move the 'missing storage layout error' from `getStorageLayout` to `getBuildInfo`


### PR DESCRIPTION
This error message was never getting triggered because of the newly added `addEnumMembersToStorageLayout` function in `getBuildInfo`.