### PR TITLE
maint(exec): remove port environment variable

### DIFF
--- a/.changeset/clean-kangaroos-camp.md
+++ b/.changeset/clean-kangaroos-camp.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/executor': patch
+---
+
+Removes an unnecessary environment variable in the ChugSplashExecutor.

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -53,7 +53,6 @@ export class ChugSplashExecutor extends BaseServiceV2<
       loop: true,
       options: {
         loopIntervalMs: 5000,
-        port: parseInt(process.env.EXECUTOR_PORT ?? '7300', 10),
         ...options,
       },
       optionsSpec: {


### PR DESCRIPTION
It's no longer necessary to supply port as an environment variable. Port is now a default option which means that it can be set as an environment variable with the format SERVICE_NAME__PORT.