### PR TITLE
fix(core,pg): remove hard-coded chain id 31337

### DIFF
--- a/.changeset/ninety-drinks-wash.md
+++ b/.changeset/ninety-drinks-wash.md
@@ -1,0 +1,6 @@
+---
+'@chugsplash/plugins': patch
+'@chugsplash/core': patch
+---
+
+Remove hard-coded chain id 31337

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -2,7 +2,6 @@ import process from 'process'
 
 import { ethers } from 'ethers'
 import ora from 'ora'
-import { getChainId } from '@eth-optimism/core-utils'
 import Hash from 'ipfs-only-hash'
 import { create } from 'ipfs-http-client'
 import { ProxyABI } from '@chugsplash/contracts'
@@ -218,15 +217,13 @@ with a name other than ${parsedConfig.options.projectName}`
         `${parsedConfig.options.projectName} has not been proposed before.`
       )
 
-      const chainId = await getChainId(provider)
-
       await proposeChugSplashBundle(
         provider,
         signer,
         parsedConfig,
         bundle,
         configUri,
-        remoteExecution || chainId !== 31337,
+        remoteExecution,
         ipfsUrl,
         configPath,
         spinner,
@@ -763,14 +760,13 @@ export const chugsplashDeployAbstractTask = async (
   if (currBundleStatus === ChugSplashBundleStatus.EMPTY) {
     spinner.succeed(`${projectName} has not been proposed before.`)
     spinner.start(`Proposing ${projectName}...`)
-    const chainId = await getChainId(provider)
     await proposeChugSplashBundle(
       provider,
       signer,
       parsedConfig,
       bundle,
       configUri,
-      remoteExecution || chainId !== 31337,
+      remoteExecution,
       ipfsUrl,
       configPath,
       spinner,

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -49,7 +49,8 @@ export const deployAllChugSplashConfigs = async (
   confirm: boolean,
   fileNames?: string[]
 ) => {
-  const remoteExecution = (await getChainId(hre.ethers.provider)) !== 31337
+  const remoteExecution =
+    (await getChainId(hre.ethers.provider)) !== hre.network.config.chainId
   fileNames =
     fileNames ?? (await fetchFilesRecursively(hre.config.paths.chugsplash))
 
@@ -102,7 +103,7 @@ export const getContract = async (
   projectName: string,
   referenceName: string
 ): Promise<ethers.Contract> => {
-  if ((await getChainId(hre.ethers.provider)) !== 31337) {
+  if ((await getChainId(hre.ethers.provider)) !== hre.network.config.chainId) {
     throw new Error('Only the Hardhat Network is currently supported.')
   }
   const userConfigs: UserChugSplashConfig[] = fetchFilesRecursively(

--- a/packages/plugins/src/hardhat/tasks.ts
+++ b/packages/plugins/src/hardhat/tasks.ts
@@ -145,7 +145,8 @@ export const chugsplashDeployTask = async (
   const provider = hre.ethers.provider
   const signer = provider.getSigner()
   const signerAddress = await signer.getAddress()
-  const remoteExecution = (await getChainId(provider)) !== 31337
+  const remoteExecution =
+    (await getChainId(provider)) !== hre.network.config.chainId
 
   let executor: ChugSplashExecutorType | undefined
   if (remoteExecution) {
@@ -361,7 +362,8 @@ export const chugsplashApproveTask = async (
   const canonicalConfigPath = hre.config.paths.canonicalConfigs
   const deploymentFolder = hre.config.paths.deployments
 
-  const remoteExecution = (await getChainId(provider)) !== 31337
+  const remoteExecution =
+    (await getChainId(provider)) !== hre.network.config.chainId
 
   const userConfig = readUserChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
@@ -617,7 +619,8 @@ export const monitorTask = async (
   const canonicalConfigPath = hre.config.paths.canonicalConfigs
   const deploymentFolder = hre.config.paths.deployments
 
-  const remoteExecution = (await getChainId(provider)) !== 31337
+  const remoteExecution =
+    (await getChainId(provider)) !== hre.network.config.chainId
 
   const userConfig = readUserChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
@@ -770,12 +773,15 @@ task(TASK_TEST)
       const { show, noCompile, configPath } = args
       const chainId = await getChainId(hre.ethers.provider)
       const signer = hre.ethers.provider.getSigner()
-      const executor = chainId === 31337 ? await signer.getAddress() : EXECUTOR
+      const executor =
+        chainId === hre.network.config.chainId
+          ? await signer.getAddress()
+          : EXECUTOR
       const networkName = await resolveNetworkName(
         hre.ethers.provider,
         'hardhat'
       )
-      if (chainId === 31337) {
+      if (chainId === hre.network.config.chainId) {
         try {
           const snapshotIdPath = path.join(
             path.basename(hre.config.paths.deployments),
@@ -841,9 +847,12 @@ task(TASK_RUN)
         const signer = hre.ethers.provider.getSigner()
         const chainId = await getChainId(hre.ethers.provider)
 
-        const confirm = chainId === 31337 ? true : args.confirm
+        const confirm =
+          chainId === hre.network.config.chainId ? true : args.confirm
         const executor =
-          chainId === 31337 ? await signer.getAddress() : EXECUTOR
+          chainId === hre.network.config.chainId
+            ? await signer.getAddress()
+            : EXECUTOR
         await initializeChugSplash(hre.ethers.provider, signer, executor)
         if (!noCompile) {
           await hre.run(TASK_COMPILE, {


### PR DESCRIPTION
This PR fixes an issue where Hardhat networks that didn't use the default chain id, 31337, would freeze when calling any ChugSplash task.