### PR TITLE
Revert "maint(exec): remove log level hack"

### DIFF
--- a/.changeset/rich-cats-fry.md
+++ b/.changeset/rich-cats-fry.md
@@ -1,7 +1,0 @@
----
-'@chugsplash/executor': patch
-'@chugsplash/plugins': patch
-'@chugsplash/core': patch
----
-
-Removes a legacy hack in the ChugSplashExecutor

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,4 @@
-import { BaseServiceV2 } from '@eth-optimism/common-ts'
+import { BaseServiceV2, LogLevel } from '@eth-optimism/common-ts'
 import { ethers } from 'ethers'
 
 import { Integration } from './constants'
@@ -13,6 +13,7 @@ export type ExecutorOptions = {
   url: string
   network: string
   privateKey: string
+  logLevel: LogLevel
 }
 export type ExecutorMetrics = {}
 export type ExecutorState = {

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -3,6 +3,7 @@ dotenv.config()
 import {
   BaseServiceV2,
   StandardOptions,
+  Logger,
   validators,
 } from '@eth-optimism/common-ts'
 import { ethers } from 'ethers'
@@ -71,6 +72,11 @@ export class ChugSplashExecutor extends BaseServiceV2<
           default:
             '0xdf57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e',
         },
+        logLevel: {
+          desc: 'Executor log level',
+          validator: validators.str,
+          default: 'error',
+        },
       },
       metricsSpec: {},
     })
@@ -88,6 +94,11 @@ export class ChugSplashExecutor extends BaseServiceV2<
     remoteExecution: boolean,
     provider?: ethers.providers.JsonRpcProvider
   ) {
+    this.logger = new Logger({
+      name: 'Logger',
+      level: options.logLevel,
+    })
+
     const reg = CHUGSPLASH_REGISTRY_PROXY_ADDRESS
     this.state.provider =
       provider ?? new ethers.providers.JsonRpcProvider(options.url)

--- a/packages/plugins/src/executor.ts
+++ b/packages/plugins/src/executor.ts
@@ -8,7 +8,6 @@ export const initializeExecutor = async (
   // Instantiate the executor.
   const executor = new ChugSplashExecutor({
     useArgv: false,
-    logLevel: 'error',
   })
 
   // Setup the executor.
@@ -16,6 +15,7 @@ export const initializeExecutor = async (
     {
       privateKey:
         '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+      logLevel: 'error',
     },
     false,
     provider


### PR DESCRIPTION
Reverts chugsplash/chugsplash#481

This is because the log level bug does not seem to be fully resolved. This PR is causing our integration test suite for the foundry library to fail. 