### PR TITLE
feat(core): set immutable variables in the ChugSplash file via the constructorArgs field

### DIFF
--- a/.changeset/green-walls-drum.md
+++ b/.changeset/green-walls-drum.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': minor
+---
+
+Set immutable variables in the ChugSplash file via the 'constructorArgs' field

--- a/packages/core/src/actions/bundle.ts
+++ b/packages/core/src/actions/bundle.ts
@@ -9,8 +9,6 @@ import {
   readContractArtifact,
   readStorageLayout,
   getCreationCodeWithConstructorArgs,
-  getImmutableVariables,
-  readBuildInfo,
 } from './artifacts'
 import {
   ChugSplashAction,
@@ -233,34 +231,20 @@ export const bundleLocal = async (
       integration
     )
 
-    const { abi, sourceName, contractName, bytecode } = readContractArtifact(
+    const { abi, bytecode } = readContractArtifact(
       artifactPaths,
       contractConfig.contract,
       integration
-    )
-    const { output: compilerOutput } = readBuildInfo(
-      artifactPaths,
-      contractConfig.contract
     )
     const creationCode = getCreationCodeWithConstructorArgs(
       bytecode,
       parsedConfig,
       referenceName,
-      abi,
-      compilerOutput,
-      sourceName,
-      contractName
-    )
-    const immutableVariables = getImmutableVariables(
-      compilerOutput,
-      sourceName,
-      contractName,
-      parsedConfig.contracts[referenceName]
+      abi
     )
     artifacts[referenceName] = {
       creationCode,
       storageLayout,
-      immutableVariables,
     }
   }
 

--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -207,8 +207,13 @@ export const parseChugSplashConfig = async (
       )
     }
 
-    const { contract, externalProxy, externalProxyType, variables } =
-      userContractConfig
+    const {
+      contract,
+      externalProxy,
+      externalProxyType,
+      variables,
+      constructorArgs,
+    } = userContractConfig
 
     // Change the `contract` fields to be a fully qualified name. This ensures that it's easy for the
     // executor to create the `CanonicalConfigArtifacts` when it eventually compiles the canonical
@@ -233,6 +238,7 @@ export const parseChugSplashConfig = async (
       proxy,
       proxyType,
       variables: variables ?? {},
+      constructorArgs: constructorArgs ?? {},
     }
 
     contracts[referenceName] = proxy
@@ -258,7 +264,6 @@ export const makeActionBundleFromConfig = async (
     [name: string]: {
       creationCode: string
       storageLayout: SolidityStorageLayout
-      immutableVariables: string[]
     }
   }
 ): Promise<ChugSplashActionBundle> => {
@@ -281,11 +286,7 @@ export const makeActionBundleFromConfig = async (
 
     // Compute our storage slots.
     // TODO: One day we'll need to refactor this to support Vyper.
-    const slots = computeStorageSlots(
-      artifact.storageLayout,
-      contractConfig,
-      artifact.immutableVariables
-    )
+    const slots = computeStorageSlots(artifact.storageLayout, contractConfig)
 
     // Add SET_STORAGE actions for each storage slot that we want to modify.
     for (const slot of slots) {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -59,6 +59,7 @@ export type UserContractConfig = {
   externalProxy?: string
   externalProxyType?: ExternalProxyType
   variables?: UserConfigVariables
+  constructorArgs?: UserConfigVariables
 }
 
 export type UserContractConfigs = {
@@ -79,6 +80,7 @@ export type ParsedContractConfig = {
   proxy: string
   proxyType: ProxyType
   variables: ParsedConfigVariables
+  constructorArgs: ParsedConfigVariables
 }
 
 export type ParsedContractConfigs = {

--- a/packages/core/src/languages/solidity/compiler.ts
+++ b/packages/core/src/languages/solidity/compiler.ts
@@ -15,7 +15,6 @@ import {
 import {
   ChugSplashActionBundle,
   getCreationCodeWithConstructorArgs,
-  getImmutableVariables,
 } from '../../actions'
 import {
   CompilerInput,
@@ -136,16 +135,7 @@ export const getCanonicalConfigArtifacts = async (
           add0x(contractOutput.evm.bytecode.object),
           canonicalConfig,
           referenceName,
-          contractOutput.abi,
-          compilerOutput,
-          sourceName,
-          contractName
-        )
-        const immutableVariables = getImmutableVariables(
-          compilerOutput,
-          sourceName,
-          contractName,
-          canonicalConfig.contracts[referenceName]
+          contractOutput.abi
         )
 
         addEnumMembersToStorageLayout(
@@ -157,7 +147,6 @@ export const getCanonicalConfigArtifacts = async (
         artifacts[referenceName] = {
           creationCode,
           storageLayout: contractOutput.storageLayout,
-          immutableVariables,
           abi: contractOutput.abi,
           compilerOutput,
           sourceName,
@@ -265,20 +254,4 @@ export const getMinimumSourceNames = (
     }
   }
   return minimumSourceNames
-}
-
-export const mapContractAstIdsToSourceNames = (
-  outputSources: CompilerOutputSources
-): { [astId: number]: string } => {
-  const contractAstIdsToSourceNames: { [astId: number]: string } = {}
-  for (const [sourceName, { ast }] of Object.entries(outputSources)) {
-    if (ast.nodes !== undefined) {
-      for (const node of ast.nodes) {
-        if (node.name !== undefined) {
-          contractAstIdsToSourceNames[node.id] = sourceName
-        }
-      }
-    }
-  }
-  return contractAstIdsToSourceNames
 }

--- a/packages/core/src/languages/solidity/storage.ts
+++ b/packages/core/src/languages/solidity/storage.ts
@@ -499,8 +499,7 @@ export const encodeBytesArrayElements = (
  */
 export const computeStorageSlots = (
   storageLayout: SolidityStorageLayout,
-  contractConfig: ParsedContractConfig,
-  immutableVariables: string[]
+  contractConfig: ParsedContractConfig
 ): Array<StorageSlotPair> => {
   const storageEntries: { [storageObjLabel: string]: SolidityStorageObj } = {}
   for (const storageObj of Object.values(storageLayout.storage)) {
@@ -508,8 +507,9 @@ export const computeStorageSlots = (
       storageEntries[storageObj.label] = storageObj
     } else {
       throw new Error(
-        `Could not find variable "${storageObj.label}" from the contract "${contractConfig.contract}" in your ChugSplash config file.\n` +
-          `You must configure all variables that are defined in the contract.\n` +
+        `Detected a variable "${storageObj.label}" from the contract "${contractConfig.contract}" (or one\n` +
+          `of its parent contracts), but could not find a corresponding variable definition in your ChugSplash file.\n` +
+          `Every variable defined in your contracts must be assigned a value in your ChugSplash file.\n` +
           `Please define the variable in your ChugSplash config file then run this command again.\n` +
           `If this problem persists, delete your cache folder then try again.`
       )
@@ -520,20 +520,18 @@ export const computeStorageSlots = (
   for (const [variableName, variableValue] of Object.entries(
     contractConfig.variables
   )) {
-    if (immutableVariables.includes(variableName)) {
-      continue
-    }
-
     // Find the entry in the storage layout that corresponds to this variable name.
     const storageObj = storageEntries[variableName]
 
     // Complain very loudly if attempting to set a variable that doesn't exist within this layout.
     if (!storageObj) {
       throw new Error(
-        `Variable "${variableName}" was defined in the ChugSplash config file for ${contractConfig.contract}\n` +
-          `but does not exist as a variable in the contract. Please add the variable in the contract or remove\n` +
-          `the variable definition in the ChugSplash config file.\n` +
-          `If this problem persists, delete your cache folder then try again.`
+        `Variable "${variableName}" was defined in the ChugSplash file for ${contractConfig.contract} but\n` +
+          `does not exist as a mutable variable in the contract. If "${variableName}" is immutable, please remove\n` +
+          `its definition in the 'variables' section of the ChugSplash file and use the 'constructorArgs' field\n` +
+          `instead. If this variable is not meant to be immutable, you can fix this error by defining a mutable\n` +
+          `variable in the contract with the name "${variableName}", or by removing its variable definition in the\n` +
+          `ChugSplash file. If this problem persists, delete your cache folder then try again.`
       )
     }
 

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -12,6 +12,7 @@ import {
   ParsedChugSplashConfig,
 } from '../config'
 import {
+  assertValidContracts,
   assertValidUpgrade,
   computeBundleId,
   displayDeploymentTable,
@@ -128,6 +129,8 @@ export const chugsplashProposeAbstractTask = async (
   if (integration === 'hardhat') {
     spinner.start('Booting up ChugSplash...')
   }
+
+  assertValidContracts(parsedConfig, artifactPaths)
 
   await assertValidUpgrade(
     provider,
@@ -673,6 +676,8 @@ export const chugsplashDeployAbstractTask = async (
   )
 
   spinner.succeed(`Parsed ${projectName}.`)
+
+  assertValidContracts(parsedConfig, artifactPaths)
 
   await assertValidUpgrade(
     provider,

--- a/packages/executor/src/utils/etherscan.ts
+++ b/packages/executor/src/utils/etherscan.ts
@@ -106,14 +106,11 @@ export const verifyChugSplashConfig = async (
     canonicalConfig.contracts
   )) {
     const artifact = artifacts[referenceName]
-    const { abi, contractName, sourceName, compilerOutput } = artifact
+    const { abi, contractName, sourceName } = artifact
     const { constructorArgValues } = getConstructorArgs(
       canonicalConfig,
       referenceName,
-      abi,
-      compilerOutput,
-      sourceName,
-      contractName
+      abi
     )
     const implementationAddress = await ChugSplashManager.implementations(
       ethers.utils.keccak256(
@@ -281,6 +278,7 @@ export const attemptVerification = async (
 
   const solcFullVersion = await getLongVersion(solcVersion)
 
+  // TODO: We can replace this by ABI-encoding the result of our `getConstructorArgs` function.
   const constructorArgsAbiEncoded = await encodeArguments(
     abi,
     sourceName,


### PR DESCRIPTION
Previously, we had logic that inferred constructor arguments based on a user's immutable variable definitions in their ChugSplash file. This was a brittle approach that became particularly unreliable when immutable variables are passed into the constructors of parent contracts.

This PR fixes that issue by allowing users to define a 'constructorArgs' field in their ChugSplash file. We perform checks to ensure that their constructor(s) are deterministic by parsing the AST nodes of each contract and its parent contracts.