### PR TITLE
fix(pg): make OpenZeppelin proxy addresses consistent in tests

### DIFF
--- a/.changeset/rich-gorillas-kiss.md
+++ b/.changeset/rich-gorillas-kiss.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/plugins': patch
+---
+
+Make OpenZeppelin proxy addresses consistent in tests

--- a/packages/plugins/chugsplash/hardhat/TransparentUpgradableUpgrade.config.ts
+++ b/packages/plugins/chugsplash/hardhat/TransparentUpgradableUpgrade.config.ts
@@ -16,7 +16,7 @@ const config: UserChugSplashConfig = {
         __gap: [],
         _owner: '0x1111111111111111111111111111111111111111',
       },
-      externalProxy: '0x7a2088a1bFc9d81c55368AE168C2C02570cB814F',
+      externalProxy: '0xC469e7aE4aD962c30c7111dc580B4adbc7E914DD',
       externalProxyType: 'oz-transparent',
     },
   },

--- a/packages/plugins/chugsplash/hardhat/UUPSUpgradableUpgrade.config.ts
+++ b/packages/plugins/chugsplash/hardhat/UUPSUpgradableUpgrade.config.ts
@@ -16,7 +16,7 @@ const config: UserChugSplashConfig = {
         __gap: [],
         _owner: '0x1111111111111111111111111111111111111111',
       },
-      externalProxy: '0x70e0bA845a1A0F2DA3359C97E0285013525FFC49',
+      externalProxy: '0xC92B72ecf468D2642992b195bea99F9B9BB4A838',
       externalProxyType: 'oz-uups',
     },
   },

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -49,6 +49,7 @@
     "yesno": "^0.4.0"
   },
   "devDependencies": {
+    "@openzeppelin/contracts": "^4.8.1",
     "@openzeppelin/hardhat-upgrades": "^1.22.1",
     "chai": "^4.3.7",
     "hardhat": "^2.10.0"


### PR DESCRIPTION
This PR changes the deployer of the OpenZeppelin proxies in `Transfer.spec.ts` to ensure that the proxy addresses remain consistent with the addresses defined in the corresponding `externalProxy` fields.