### PR TITLE
fix(core): validate usage of the preserve keyword

### DIFF
--- a/.changeset/hungry-squids-arrive.md
+++ b/.changeset/hungry-squids-arrive.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Validate usage of the preserve keyword

--- a/docs/special-var-defs.md
+++ b/docs/special-var-defs.md
@@ -31,7 +31,7 @@ myToken: "{{MyToken              }}"
 
 ## Preserve Keyword
 
-During an upgrade, you'll probably want to leave the values of some variables untouched. For example, if you have a `counter` variable that's incremented every time a user performs an action, you probably won't want to overwrite its existing value since it can change at any time. To prevent its value from being overwritten, use the preserve keyword:
+During an upgrade, you may want to leave the values of some variables untouched. For example, if you have a `counter` variable that's incremented every time a user performs an action, you probably won't want to overwrite its existing value since it can change at any time. To prevent its value from being overwritten, use the preserve keyword:
 
 ```ts
 counter: '{ preserve }'
@@ -63,7 +63,7 @@ The preserve keyword works for arbitrarily nested variables.
 
 Using the preserve keyword will cause ChugSplash to omit the `SetStorage` action for the variable (or its member). This means ChugSplash will not modify its value when it upgrades the contract.
 
-You can only use the preserve keyword for state variables that have the same exact type and storage slot position (i.e. storage slot key and offset) in the original contract and its upgraded version. Additionally, you can only use the keyword when upgrading a contract (not for a fresh deployment). Lastly, you cannot use the preserve keyword for immutable variables. If any of these conditions aren't met, ChugSplash will throw a helpful error when compiling your ChugSplash file.
+You can only use the preserve keyword for state variables that have the same exact type and storage slot position (i.e. storage slot key and offset) in the original contract and its upgraded version. Additionally, you can only use the keyword when upgrading a contract (not for a fresh deployment). Lastly, you cannot use the preserve keyword for immutable variables. If any of these conditions aren't met, ChugSplash will throw an error when compiling your ChugSplash file.
 
 The preserve keyword is not case sensitive, and allows whitespace. In other words, the following variations of the preserve keyword are valid:
 ```


### PR DESCRIPTION
The preserve keyword can only be used for variables that:
1. Exist in the previous storage layout with the same name
2. Exist at the same storage slot key and offset
3. Have the same type