### PR TITLE
feat(core): Add support for async config files

### DIFF
--- a/.changeset/brave-clocks-act.md
+++ b/.changeset/brave-clocks-act.md
@@ -1,0 +1,6 @@
+---
+'@chugsplash/plugins': patch
+'@chugsplash/core': patch
+---
+
+Add support for async config files

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -673,7 +673,7 @@ export const chugsplashDeployAbstractTask = async (
 
   spinner.start('Parsing ChugSplash config file...')
 
-  const userConfig = readUserChugSplashConfig(configPath)
+  const userConfig = await readUserChugSplashConfig(configPath)
   const parsedConfig = await readParsedChugSplashConfig(
     provider,
     configPath,

--- a/packages/plugins/src/foundry/index.ts
+++ b/packages/plugins/src/foundry/index.ts
@@ -50,7 +50,7 @@ const command = args[0]
         outPath,
         buildInfoPath
       )
-      const userConfig = readUserChugSplashConfig(configPath)
+      const userConfig = await readUserChugSplashConfig(configPath)
       const artifactPaths = await getArtifactPaths(
         userConfig.contracts,
         artifactFolder,
@@ -95,7 +95,7 @@ const command = args[0]
 
       const { artifactFolder, buildInfoFolder, canonicalConfigPath } =
         fetchPaths(outPath, buildInfoPath)
-      const userConfig = readUserChugSplashConfig(configPath)
+      const userConfig = await readUserChugSplashConfig(configPath)
       const artifactPaths = await getArtifactPaths(
         userConfig.contracts,
         artifactFolder,
@@ -150,7 +150,7 @@ const command = args[0]
         outPath,
         buildInfoPath
       )
-      const userConfig = readUserChugSplashConfig(configPath)
+      const userConfig = await readUserChugSplashConfig(configPath)
       const artifactPaths = await getArtifactPaths(
         userConfig.contracts,
         artifactFolder,
@@ -194,7 +194,7 @@ const command = args[0]
         deploymentFolder,
         canonicalConfigPath,
       } = fetchPaths(outPath, buildInfoPath)
-      const userConfig = readUserChugSplashConfig(configPath)
+      const userConfig = await readUserChugSplashConfig(configPath)
       const artifactPaths = await getArtifactPaths(
         userConfig.contracts,
         artifactFolder,
@@ -259,7 +259,7 @@ const command = args[0]
         deploymentFolder,
         canonicalConfigPath,
       } = fetchPaths(outPath, buildInfoPath)
-      const userConfig = readUserChugSplashConfig(configPath)
+      const userConfig = await readUserChugSplashConfig(configPath)
       const artifactPaths = await getArtifactPaths(
         userConfig.contracts,
         artifactFolder,
@@ -337,7 +337,7 @@ const command = args[0]
         deploymentFolder,
         canonicalConfigPath,
       } = fetchPaths(outPath, buildInfoPath)
-      const userConfig = readUserChugSplashConfig(configPath)
+      const userConfig = await readUserChugSplashConfig(configPath)
       const artifactPaths = await getArtifactPaths(
         userConfig.contracts,
         artifactFolder,
@@ -383,7 +383,7 @@ const command = args[0]
         outPath,
         buildInfoPath
       )
-      const userConfig = readUserChugSplashConfig(configPath)
+      const userConfig = await readUserChugSplashConfig(configPath)
       const artifactPaths = await getArtifactPaths(
         userConfig.contracts,
         artifactFolder,
@@ -417,7 +417,7 @@ const command = args[0]
 
       const { artifactFolder, buildInfoFolder, canonicalConfigPath } =
         fetchPaths(outPath, buildInfoPath)
-      const userConfig = readUserChugSplashConfig(configPath)
+      const userConfig = await readUserChugSplashConfig(configPath)
       const artifactPaths = await getArtifactPaths(
         userConfig.contracts,
         artifactFolder,
@@ -475,7 +475,7 @@ const command = args[0]
         outPath,
         buildInfoPath
       )
-      const userConfig = readUserChugSplashConfig(configPath)
+      const userConfig = await readUserChugSplashConfig(configPath)
       const artifactPaths = await getArtifactPaths(
         userConfig.contracts,
         artifactFolder,
@@ -510,7 +510,7 @@ const command = args[0]
         outPath,
         buildInfoPath
       )
-      const userConfig = readUserChugSplashConfig(configPath)
+      const userConfig = await readUserChugSplashConfig(configPath)
       const artifactPaths = await getArtifactPaths(
         userConfig.contracts,
         artifactFolder,
@@ -548,7 +548,7 @@ const command = args[0]
         outPath,
         buildInfoPath
       )
-      const userConfig = readUserChugSplashConfig(configPath)
+      const userConfig = await readUserChugSplashConfig(configPath)
       const artifactPaths = await getArtifactPaths(
         userConfig.contracts,
         artifactFolder,
@@ -589,7 +589,7 @@ const command = args[0]
         outPath,
         buildInfoPath
       )
-      const userConfig = readUserChugSplashConfig(configPath)
+      const userConfig = await readUserChugSplashConfig(configPath)
       const artifactPaths = await getArtifactPaths(
         userConfig.contracts,
         artifactFolder,
@@ -628,7 +628,7 @@ const command = args[0]
         outPath,
         buildInfoPath
       )
-      const userConfig = readUserChugSplashConfig(configPath)
+      const userConfig = await readUserChugSplashConfig(configPath)
       const artifactPaths = await getArtifactPaths(
         userConfig.contracts,
         artifactFolder,

--- a/packages/plugins/src/hardhat/tasks.ts
+++ b/packages/plugins/src/hardhat/tasks.ts
@@ -170,7 +170,7 @@ export const chugsplashDeployTask = async (
   const canonicalConfigPath = hre.config.paths.canonicalConfigs
   const deploymentFolder = hre.config.paths.deployments
 
-  const userConfig = readUserChugSplashConfig(configPath)
+  const userConfig = await readUserChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
     hre,
     userConfig.contracts,
@@ -254,7 +254,7 @@ export const chugsplashRegisterTask = async (
   const signerAddress = await signer.getAddress()
   await initializeChugSplash(hre.ethers.provider, signer, [signerAddress])
 
-  const userConfig = readUserChugSplashConfig(configPath)
+  const userConfig = await readUserChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
     hre,
     userConfig.contracts,
@@ -311,8 +311,7 @@ export const chugsplashProposeTask = async (
   const signerAddress = await signer.getAddress()
   await initializeChugSplash(hre.ethers.provider, signer, [signerAddress])
 
-  const userConfig = readUserChugSplashConfig(configPath)
-
+  const userConfig = await readUserChugSplashConfig(configPath)
   const canonicalConfigPath = hre.config.paths.canonicalConfigs
 
   const artifactPaths = await getArtifactPaths(
@@ -395,7 +394,7 @@ export const chugsplashApproveTask = async (
 
   const remoteExecution = await isRemoteExecution(hre)
 
-  const userConfig = readUserChugSplashConfig(configPath)
+  const userConfig = await readUserChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
     hre,
     userConfig.contracts,
@@ -654,7 +653,7 @@ export const monitorTask = async (
 
   const remoteExecution = await isRemoteExecution(hre)
 
-  const userConfig = readUserChugSplashConfig(configPath)
+  const userConfig = await readUserChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
     hre,
     userConfig.contracts,
@@ -702,7 +701,7 @@ export const chugsplashFundTask = async (
   const signerAddress = await signer.getAddress()
   await initializeChugSplash(hre.ethers.provider, signer, [signerAddress])
 
-  const userConfig = readUserChugSplashConfig(configPath)
+  const userConfig = await readUserChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
     hre,
     userConfig.contracts,
@@ -909,9 +908,10 @@ export const chugsplashCancelTask = async (
   const provider = hre.ethers.provider
   const signer = provider.getSigner()
 
+  const config = await readUserChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
     hre,
-    readUserChugSplashConfig(configPath).contracts,
+    config.contracts,
     hre.config.paths.artifacts,
     path.join(hre.config.paths.artifacts, 'build-info')
   )
@@ -943,7 +943,7 @@ export const chugsplashWithdrawTask = async (
   const signer = provider.getSigner()
   const canonicalConfigPath = hre.config.paths.canonicalConfigs
 
-  const userConfig = readUserChugSplashConfig(configPath)
+  const userConfig = await readUserChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
     hre,
     userConfig.contracts,
@@ -990,9 +990,10 @@ export const listProposersTask = async (
   const provider = hre.ethers.provider
   const signer = provider.getSigner()
 
+  const config = await readUserChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
     hre,
-    readUserChugSplashConfig(configPath).contracts,
+    config.contracts,
     hre.config.paths.artifacts,
     path.join(hre.config.paths.artifacts, 'build-info')
   )
@@ -1027,9 +1028,10 @@ export const addProposerTask = async (
   const provider = hre.ethers.provider
   const signer = provider.getSigner()
 
+  const config = await readUserChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
     hre,
-    readUserChugSplashConfig(configPath).contracts,
+    config.contracts,
     hre.config.paths.artifacts,
     path.join(hre.config.paths.artifacts, 'build-info')
   )
@@ -1066,9 +1068,10 @@ export const claimProxyTask = async (
   const provider = hre.ethers.provider
   const signer = provider.getSigner()
 
+  const config = await readUserChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
     hre,
-    readUserChugSplashConfig(configPath).contracts,
+    config.contracts,
     hre.config.paths.artifacts,
     path.join(hre.config.paths.artifacts, 'build-info')
   )
@@ -1111,9 +1114,10 @@ export const transferOwnershipTask = async (
   const provider = hre.ethers.provider
   const signer = provider.getSigner()
 
+  const config = await readUserChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
     hre,
-    readUserChugSplashConfig(configPath).contracts,
+    config.contracts,
     hre.config.paths.artifacts,
     path.join(hre.config.paths.artifacts, 'build-info')
   )

--- a/packages/plugins/src/scripts/display-bundle-info.ts
+++ b/packages/plugins/src/scripts/display-bundle-info.ts
@@ -25,7 +25,7 @@ if (typeof chugsplashFilePath !== 'string') {
  * This makes it easy to generate bundles to be used when unit testing the ChugSplashManager.*
  */
 const displayBundleInfo = async () => {
-  const userConfig = readUserChugSplashConfig(chugsplashFilePath)
+  const userConfig = await readUserChugSplashConfig(chugsplashFilePath)
   const artifactPaths = await getArtifactPaths(
     hre,
     userConfig.contracts,


### PR DESCRIPTION
## Purpose
Adds support for asynchronously resolved ChugSplash configs. Users will now be able to export an asynchronous function from their config file and our tooling will take care of resolving it internally. 

## Context
I was integrating [Gelato Relay](https://github.com/gelatodigital/relay-contracts) (which appears to be their primary focus right now, though it is not their core protocol) on the plane flight back and encountered a use case for this feature so I went ahead and implemented it. We may want to consider updating the docs to make this the recommended method of creating your config file b/c it is significantly more powerful. 

## Example
The Gelato Relay codebase includes some mock contracts used for testing. This is the config file I wrote to deploy them using the asynchronous config file feature. 

On a side note, this is also just an interesting use case for ChugSplash. These contracts will never be deployed to mainnet, but it still makes sense to use ChugSplash to deploy them IMO. BTW doing this deployment actually also required that I disable our check preventing all non immutable constructor args. [I've created a ticket related to that.](https://linear.app/chugsplash/issue/CHU-128/allow-forcing-non-immutable-constructor-args)
```js
import { UserChugSplashConfig } from "@chugsplash/core";
import { getNamedAccounts } from "hardhat";
import { INIT_TOKEN_BALANCE } from "../test/constants";

export default async (): Promise<UserChugSplashConfig> => {
  const { deployer } = await getNamedAccounts();
  return {
    options: {
      projectName: "Gelato Relay Mocks",
    },
    contracts: {
      MockERC20: {
        contract: "MockERC20",
        constructorArgs: {
          name: "MockERC20",
          symbol: "ME2",
        },
        variables: {
          // eslint-disable-next-line @typescript-eslint/naming-convention
          _name: "MockERC20",
          // eslint-disable-next-line @typescript-eslint/naming-convention
          _symbol: "ME2",
          // eslint-disable-next-line @typescript-eslint/naming-convention
          _totalSupply: INIT_TOKEN_BALANCE.toString(),
          // eslint-disable-next-line @typescript-eslint/naming-convention
          _balances: {
            [deployer]: INIT_TOKEN_BALANCE.toString(),
          },
          // eslint-disable-next-line @typescript-eslint/naming-convention
          _allowances: {},
        },
      },
      MockGelatoRelayContext: {
        contract: "MockGelatoRelayContext",
        constructorArgs: {},
        variables: {},
      },
      MockGelatoRelayContextERC2771: {
        contract: "MockGelatoRelayContextERC2771",
        constructorArgs: {},
        variables: {},
      },
      MockGelatoRelayFeeCollector: {
        contract: "MockGelatoRelayFeeCollector",
        constructorArgs: {},
        variables: {},
      },
      MockGelatoRelayFeeCollectorERC2771: {
        contract: "MockGelatoRelayFeeCollectorERC2771",
        constructorArgs: {},
        variables: {},
      }
    },
  };
};
``` 
