### PR TITLE
refactor(core): add initial value to reduce call

### DIFF
--- a/packages/core/src/fund.ts
+++ b/packages/core/src/fund.ts
@@ -88,9 +88,10 @@ export const estimateExecutionGas = async (
   )
 
   const estimatedContractDeploymentGas =
-    resolvedContractDeploymentPromises.length > 0
-      ? resolvedContractDeploymentPromises.reduce((a, b) => a.add(b))
-      : ethers.BigNumber.from(0)
+    resolvedContractDeploymentPromises.reduce(
+      (a, b) => a.add(b),
+      ethers.BigNumber.from(0)
+    )
 
   estimatedGas = estimatedGas.add(estimatedContractDeploymentGas)
 


### PR DESCRIPTION
Calling [reduce](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce) on an empty array without an initial value causes an error to be thrown.