### PR TITLE
maint(core): Bring rest of config validation into the parse config interface

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "@eth-optimism/contracts-bedrock": "^0.8.0",
     "@eth-optimism/core-utils": "^0.9.1",
     "@ethersproject/abstract-provider": "^5.7.0",
+    "@openzeppelin/hardhat-upgrades": "^1.22.1",
     "@openzeppelin/upgrades-core": "^1.20.6",
     "core-js": "^3.27.1",
     "ethers": "^5.6.9",

--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -7,6 +7,14 @@ import { astDereferencer, ASTDereferencer } from 'solidity-ast/utils'
 import { CompilerOutput } from 'hardhat/types'
 import { remove0x } from '@eth-optimism/core-utils'
 import { Fragment } from 'ethers/lib/utils'
+import {
+  assertStorageUpgradeSafe,
+  StorageLayout,
+} from '@openzeppelin/upgrades-core'
+import { OZ_UUPS_UPDATER_ADDRESS, ProxyABI } from '@chugsplash/contracts'
+import { getDetailedLayout } from '@openzeppelin/upgrades-core/dist/storage/layout'
+import yesno from 'yesno'
+import { ContractDefinition } from 'solidity-ast'
 
 import {
   ArtifactPaths,
@@ -20,6 +28,13 @@ import {
   readContractArtifact,
   assertValidContractReferences,
   readBuildInfo,
+  getChugSplashManagerProxyAddress,
+  getEIP1967ProxyAdminAddress,
+  getPreviousStorageLayoutOZFormat,
+  getOpenZeppelinStorageLayout,
+  isEqualType,
+  getOpenZeppelinValidationOpts,
+  getParentContractASTNodes,
 } from '../utils'
 import {
   UserChugSplashConfig,
@@ -30,6 +45,7 @@ import {
   UserConfigVariable,
   UserConfigVariables,
   ParsedConfigVariables,
+  ParsedContractConfig,
 } from './types'
 import { Integration } from '../constants'
 import {
@@ -44,6 +60,7 @@ import {
   VariableHandlerProps,
   buildMappingStorageObj,
 } from '../languages/solidity/iterator'
+import { ChugSplashRuntimeEnvironment } from '../types'
 
 class InputError extends Error {
   constructor(message) {
@@ -53,27 +70,29 @@ class InputError extends Error {
 }
 
 /**
- * Reads a ChugSplash config file synchronously.
+ * Reads a ChugSplash config file and completes full parsing and validation on it.
  *
  * @param configPath Path to the ChugSplash config file.
  * @returns The parsed ChugSplash config file.
  */
-export const readParsedChugSplashConfig = async (
+export const readValidatedChugSplashConfig = async (
   provider: providers.Provider,
   configPath: string,
   artifactPaths: ArtifactPaths,
-  integration: Integration
+  integration: Integration,
+  cre: ChugSplashRuntimeEnvironment
 ): Promise<ParsedChugSplashConfig> => {
-  const userConfig = await readUserChugSplashConfig(configPath)
+  const userConfig = await readUnvalidatedChugSplashConfig(configPath)
   return parseAndValidateChugSplashConfig(
     provider,
     userConfig,
     artifactPaths,
-    integration
+    integration,
+    cre
   )
 }
 
-export const readUserChugSplashConfig = async (
+export const readUnvalidatedChugSplashConfig = async (
   configPath: string
 ): Promise<UserChugSplashConfig> => {
   delete require.cache[require.resolve(path.resolve(configPath))]
@@ -91,8 +110,6 @@ export const readUserChugSplashConfig = async (
       'Config file must export either a config object, or a function which resolves to one.'
     )
   }
-
-  assertValidUserConfigFields(config)
   return config
 }
 
@@ -965,6 +982,372 @@ export const parseAndValidateConstructorArgs = (
   return parsedConstructorArgs
 }
 
+export const assertStorageCompatiblePreserveKeywords = (
+  contractConfig: ParsedContractConfig,
+  prevStorageLayout: StorageLayout,
+  newStorageLayout: StorageLayout
+) => {
+  const prevDetailedLayout = getDetailedLayout(prevStorageLayout)
+  const newDetailedLayout = getDetailedLayout(newStorageLayout)
+
+  const errorMessages: Array<string> = []
+  for (const newStorageObj of newDetailedLayout) {
+    if (
+      variableContainsPreserveKeyword(
+        contractConfig.variables[newStorageObj.label]
+      )
+    ) {
+      const validPreserveKeyword = prevDetailedLayout.some(
+        (prevObj) =>
+          prevObj.label === newStorageObj.label &&
+          prevObj.slot === newStorageObj.slot &&
+          prevObj.offset === newStorageObj.offset &&
+          isEqualType(prevObj, newStorageObj)
+      )
+
+      if (!validPreserveKeyword) {
+        errorMessages.push(
+          `The variable "${newStorageObj.label}" contains the preserve keyword, but does not exist in the previous\n` +
+            `storage layout at the same slot position with the same variable type. Please fix this or remove\n` +
+            `the preserve keyword from this variable.`
+        )
+      }
+    }
+  }
+
+  if (errorMessages.length > 0) {
+    throw new Error(`${errorMessages.join('\n\n')}`)
+  }
+}
+
+export const assertValidParsedChugSplashFile = async (
+  provider: providers.Provider,
+  parsedConfig: ParsedChugSplashConfig,
+  userConfig: UserChugSplashConfig,
+  artifactPaths: ArtifactPaths,
+  integration: Integration,
+  cre: ChugSplashRuntimeEnvironment
+) => {
+  const {
+    canonicalConfigPath,
+    remoteExecution,
+    autoConfirm,
+    openzeppelinStorageLayouts,
+  } = cre
+
+  // Determine if the deployment is an upgrade
+  const projectName = parsedConfig.options.projectName
+
+  const chugSplashManagerAddress = getChugSplashManagerProxyAddress(
+    parsedConfig.options.projectName
+  )
+
+  const requiresOwnershipTransfer: {
+    name: string
+    proxyAddress: string
+    currentAdminAddress: string
+  }[] = []
+  let isUpgrade: boolean = false
+  for (const [referenceName, contractConfig] of Object.entries(
+    parsedConfig.contracts
+  )) {
+    if ((await provider.getCode(contractConfig.proxy)) !== '0x') {
+      isUpgrade = true
+
+      if (
+        contractConfig.proxyType === 'oz-ownable-uups' ||
+        contractConfig.proxyType === 'oz-access-control-uups'
+      ) {
+        // We must manually check that the ChugSplashManager can call the UUPS proxy's `upgradeTo`
+        // function because OpenZeppelin UUPS proxies can implement arbitrary access control
+        // mechanisms.
+        const chugsplashManager = new ethers.VoidSigner(
+          chugSplashManagerAddress,
+          provider
+        )
+        const UUPSProxy = new ethers.Contract(
+          contractConfig.proxy,
+          ProxyABI,
+          chugsplashManager
+        )
+        try {
+          // Attempt to staticcall the `upgradeTo` function on the proxy from the
+          // ChugSplashManager's address. Note that it's necessary for us to set the proxy's
+          // implementation to an OpenZeppelin UUPS ProxyUpdater contract to ensure that:
+          // 1. The new implementation is deployed on every network. Otherwise, the call will revert
+          //    due to this check:
+          //    https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/proxy/ERC1967/ERC1967Upgrade.sol#L44
+          // 2. The new implementation has a public `proxiableUUID()` function. Otherwise, the call
+          //    will revert due to this check:
+          //    https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/dd8ca8adc47624c5c5e2f4d412f5f421951dcc25/contracts/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol#L91
+          await UUPSProxy.callStatic.upgradeTo(OZ_UUPS_UPDATER_ADDRESS)
+        } catch (e) {
+          // The ChugSplashManager does not have permission to call the `upgradeTo` function on the
+          // proxy, which means the user must grant it permission via whichever access control
+          // mechanism the UUPS proxy uses.
+          requiresOwnershipTransfer.push({
+            name: referenceName,
+            proxyAddress: contractConfig.proxy,
+            currentAdminAddress: 'unknown',
+          })
+        }
+      } else {
+        const proxyAdmin = await getEIP1967ProxyAdminAddress(
+          provider,
+          contractConfig.proxy
+        )
+
+        if (proxyAdmin !== chugSplashManagerAddress) {
+          requiresOwnershipTransfer.push({
+            name: referenceName,
+            proxyAddress: contractConfig.proxy,
+            currentAdminAddress: proxyAdmin,
+          })
+        }
+      }
+    }
+  }
+
+  if (requiresOwnershipTransfer.length > 0) {
+    throw new Error(
+      `Detected proxy contracts which are not managed by ChugSplash:` +
+        `${requiresOwnershipTransfer.map(
+          ({ name, proxyAddress, currentAdminAddress }) =>
+            `\n${name}: ${proxyAddress} | Current admin: ${currentAdminAddress}`
+        )}
+
+If you are using any Transparent proxies, you must transfer ownership of each to ChugSplash using the following command:
+npx hardhat chugsplash-transfer-ownership --network <network> --config-path <path> --proxy <proxyAddress>
+
+If you are using any UUPS proxies, you must give your ChugSplashManager contract ${chugSplashManagerAddress}
+permission to call the 'upgradeTo' function on each of them.
+      `
+    )
+  }
+
+  if (isUpgrade) {
+    for (const [referenceName, contractConfig] of Object.entries(
+      parsedConfig.contracts
+    )) {
+      const isProxyDeployed =
+        (await provider.getCode(contractConfig.proxy)) !== '0x'
+      if (isProxyDeployed && canonicalConfigPath) {
+        const userContractConfig = userConfig.contracts[referenceName]
+        const previousStorageLayout = await getPreviousStorageLayoutOZFormat(
+          provider,
+          referenceName,
+          contractConfig,
+          userContractConfig,
+          remoteExecution,
+          canonicalConfigPath,
+          openzeppelinStorageLayouts
+        )
+
+        const { input, output } = readBuildInfo(
+          artifactPaths[referenceName].buildInfoPath
+        )
+        const newStorageLayout = getOpenZeppelinStorageLayout(
+          contractConfig.contract,
+          input,
+          output,
+          contractConfig.proxyType
+        )
+
+        assertStorageCompatiblePreserveKeywords(
+          contractConfig,
+          previousStorageLayout,
+          newStorageLayout
+        )
+
+        // We could check for the `skipStorageCheck` in the outer for-loop, but this makes it easy to
+        // support more granular storage layout config options in the future.
+        if (parsedConfig.options.skipStorageCheck !== true) {
+          // Run OpenZeppelin's storage slot checker.
+          assertStorageUpgradeSafe(
+            previousStorageLayout,
+            newStorageLayout,
+            getOpenZeppelinValidationOpts(contractConfig.proxyType)
+          )
+        }
+      }
+
+      // Check new UUPS implementations include a public `upgradeTo` function. This ensures that the
+      // user will be able to upgrade the proxy in the future.
+      if (
+        contractConfig.proxyType === 'oz-ownable-uups' ||
+        contractConfig.proxyType === 'oz-access-control-uups'
+      ) {
+        const artifact = readContractArtifact(
+          artifactPaths[referenceName].contractArtifactPath,
+          integration
+        )
+        const containsPublicUpgradeTo = artifact.abi.some(
+          (fragment) =>
+            fragment.name === 'upgradeTo' &&
+            fragment.inputs.length === 1 &&
+            fragment.inputs[0].type === 'address'
+        )
+        if (!containsPublicUpgradeTo) {
+          throw new Error(
+            `Contract ${referenceName} proxy type is marked as UUPS, but the new implementation\n` +
+              `no longer has a public 'upgradeTo(address)' function. You must include this function \n` +
+              `or you will no longer be able to upgrade this contract.`
+          )
+        }
+      }
+    }
+
+    if (!autoConfirm) {
+      // Confirm upgrade with user
+      const userConfirmed = await yesno({
+        question: `Prior deployment(s) detected for project ${projectName}. Would you like to perform an upgrade? (y/n)`,
+      })
+      if (!userConfirmed) {
+        throw new Error(`User denied upgrade.`)
+      }
+    }
+  } else {
+    for (const contractConfig of Object.values(parsedConfig.contracts)) {
+      // Throw an error if the 'preserve' keyword is set to a variable's value in the
+      // ChugSplash config file. This keyword is only allowed for upgrades.
+      if (variableContainsPreserveKeyword(contractConfig.variables)) {
+        throw new Error(
+          `Detected the '{preserve}' keyword in a fresh deployment. This keyword is reserved for\n` +
+            `upgrades only. Please remove all instances of it in your ChugSplash config file.`
+        )
+      }
+    }
+  }
+}
+
+export const assertValidContracts = (
+  parsedConfig: ParsedChugSplashConfig,
+  artifactPaths: ArtifactPaths
+) => {
+  for (const [referenceName, contractConfig] of Object.entries(
+    parsedConfig.contracts
+  )) {
+    // Get the source name and contract name from its fully qualified name
+    const [sourceName, contractName] = contractConfig.contract.split(':')
+
+    const buildInfoPath = artifactPaths[referenceName].buildInfoPath
+    const buildInfo = readBuildInfo(buildInfoPath)
+    const outputSource = buildInfo.output.sources[sourceName]
+
+    const childContractNode = outputSource.ast.nodes.find(
+      (node): node is ContractDefinition =>
+        node.nodeType === 'ContractDefinition' && node.name === contractName
+    )
+
+    if (childContractNode === undefined) {
+      throw new Error(
+        `Could not find the child contract node for "${referenceName}"`
+      )
+    }
+
+    const parentContractNodeAstIds =
+      childContractNode.linearizedBaseContracts.filter(
+        (astId) => astId !== childContractNode.id
+      )
+    const parentContractNodes = getParentContractASTNodes(
+      buildInfo.output.sources,
+      parentContractNodeAstIds
+    )
+
+    // TODO: type
+    const constructorNodes: Array<any> = []
+    const immutableVarAstIds: { [astId: number]: boolean } = {}
+    // Create a mapping of constructor node AST IDs to the corresponding contract's name. This is only used
+    // for error messages when we parse the constructor nodes later.
+    const constructorNodeContractNames: { [astId: number]: string } = {}
+    for (const contractNode of parentContractNodes.concat([
+      childContractNode,
+    ])) {
+      for (const node of contractNode.nodes) {
+        if (node.kind === 'constructor') {
+          constructorNodes.push(node)
+          constructorNodeContractNames[node.id] = contractNode.name
+        } else if (node.nodeType === 'VariableDeclaration') {
+          if (node.mutability === 'mutable' && node.value !== undefined) {
+            throw new Error(
+              `User attempted to assign a value to a non-immutable state variable '${node.name}' in\n` +
+                `the contract: ${contractNode.name}. This is not allowed because the value will not exist in\n` +
+                `the upgradeable contract. Please remove the value in the contract and define it in your ChugSplash\n` +
+                `file instead. Alternatively, can also set '${node.name} to be a constant or immutable variable.`
+            )
+          }
+
+          if (
+            node.mutability === 'immutable' &&
+            node.value !== undefined &&
+            node.value.kind === 'functionCall'
+          ) {
+            throw new Error(
+              `User attempted to assign the immutable variable '${node.name}' to the return value of a function call in\n` +
+                `the contract: ${contractNode.name}. This is not allowed to ensure that ChugSplash is\n` +
+                `deterministic. Please remove the function call.`
+            )
+          }
+
+          if (node.mutability === 'immutable' && node.value === undefined) {
+            immutableVarAstIds[node.id] = true
+          }
+        }
+      }
+    }
+
+    for (const node of constructorNodes) {
+      for (const statement of node.body.statements) {
+        if (statement.nodeType !== 'ExpressionStatement') {
+          throw new Error(
+            `Detected an unallowed expression, '${statement.nodeType}', in the constructor of the\n` +
+              `contract: ${
+                constructorNodeContractNames[node.id]
+              }. Only immutable variable assignments are allowed in\n` +
+              `the constructor to ensure that ChugSplash can deterministically deploy your contracts.`
+          )
+        }
+
+        if (statement.expression.nodeType !== 'Assignment') {
+          const unallowedOperation: string =
+            statement.expression.expression.name ?? statement.expression.kind
+          throw new Error(
+            `Detected an unallowed operation, '${unallowedOperation}', in the constructor of the\n` +
+              `contract: ${
+                constructorNodeContractNames[node.id]
+              }. Only immutable variable assignments are allowed in\n` +
+              `the constructor to ensure that ChugSplash can deterministically deploy your contracts.`
+          )
+        }
+
+        if (
+          immutableVarAstIds[
+            statement.expression.leftHandSide.referencedDeclaration
+          ] !== true
+        ) {
+          throw new Error(
+            `Detected an assignment to a non-immutable variable, '${statement.expression.leftHandSide.name}', in the\n` +
+              `constructor of the contract: ${
+                constructorNodeContractNames[node.id]
+              }. Only immutable variable assignments are allowed in\n` +
+              `the constructor to ensure that ChugSplash can deterministically deploy your contracts.`
+          )
+        }
+
+        if (statement.expression.rightHandSide.kind === 'functionCall') {
+          throw new Error(
+            `User attempted to assign the immutable variable '${statement.expression.leftHandSide.name}' to the return \n` +
+              `value of a function call in the contract: ${
+                constructorNodeContractNames[node.id]
+              }. This is not allowed to ensure that\n` +
+              `ChugSplash is deterministic. Please remove the function call.`
+          )
+        }
+      }
+    }
+  }
+}
+
 /**
  * Parses a ChugSplash config file from the config file given by the user.
  *
@@ -976,8 +1359,11 @@ const parseAndValidateChugSplashConfig = async (
   provider: providers.Provider,
   userConfig: UserChugSplashConfig,
   artifactPaths: ArtifactPaths,
-  integration: Integration
+  integration: Integration,
+  cre: ChugSplashRuntimeEnvironment
 ): Promise<ParsedChugSplashConfig> => {
+  assertValidUserConfigFields(userConfig)
+
   const parsedConfig: ParsedChugSplashConfig = {
     options: userConfig.options,
     contracts: {},
@@ -1053,6 +1439,16 @@ const parseAndValidateChugSplashConfig = async (
 
     contracts[referenceName] = proxy
   }
+
+  assertValidContracts(parsedConfig, artifactPaths)
+  assertValidParsedChugSplashFile(
+    provider,
+    parsedConfig,
+    userConfig,
+    artifactPaths,
+    integration,
+    cre
+  )
 
   return JSON.parse(
     Handlebars.compile(JSON.stringify(parsedConfig))({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,6 +3,18 @@ import { ethers } from 'ethers'
 
 import { Integration } from './constants'
 
+export type ChugSplashRuntimeEnvironment = {
+  configPath: string
+  canonicalConfigPath: string | undefined
+  remoteExecution: boolean
+  autoConfirm: boolean
+  openzeppelinStorageLayouts:
+    | {
+        [referenceName: string]: any
+      }
+    | undefined
+}
+
 export type FoundryContractArtifact = {
   referenceName: string
   contractName: string

--- a/packages/plugins/foundry-contracts/ChugSplash.sol
+++ b/packages/plugins/foundry-contracts/ChugSplash.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.15;
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";
 import "lib/solidity-stringutils/strings.sol";
+import "forge-std/console.sol";
 
 contract ChugSplash is Script, Test {
     using strings for *;
@@ -114,7 +115,7 @@ contract ChugSplash is Script, Test {
     ) external returns (bytes memory) {
         (string memory outPath, string memory buildInfoPath) = fetchPaths();
 
-        string[] memory cmds = new string[](14);
+        string[] memory cmds = new string[](13);
         cmds[0] = "npx";
         cmds[1] = "node";
         cmds[2] = filePath;
@@ -128,7 +129,6 @@ contract ChugSplash is Script, Test {
         cmds[10] = buildInfoPath;
         cmds[11] = ipfsUrl;
         cmds[12] = remoteExecution == true ? "true" : "false";
-        cmds[13] = skipStorageCheck == true ? "true" : "false";
 
         bytes memory result = vm.ffi(cmds);
 
@@ -217,7 +217,7 @@ contract ChugSplash is Script, Test {
     ) public {
         (string memory outPath, string memory buildInfoPath) = fetchPaths();
 
-        string[] memory cmds = new string[](16);
+        string[] memory cmds = new string[](15);
         cmds[0] = "npx";
         cmds[1] = "node";
         cmds[2] = filePath;
@@ -232,8 +232,7 @@ contract ChugSplash is Script, Test {
         cmds[11] = withdrawFunds == true ? "true" : "false";
         cmds[12] = newOwner;
         cmds[13] = ipfsUrl;
-        cmds[14] = skipStorageCheck == true ? "true" : "false";
-        cmds[15] = allowManagedProposals == true ? "true" : "false";
+        cmds[14] = allowManagedProposals == true ? "true" : "false";
 
         bytes memory result = vm.ffi(cmds);
         if (isChugSplashTest) {
@@ -297,9 +296,7 @@ contract ChugSplash is Script, Test {
         string memory configPath,
         bool silent
     ) public returns (bytes memory) {
-        (string memory outPath, string memory buildInfoPath) = fetchPaths();
-
-        string[] memory cmds = new string[](10);
+        string[] memory cmds = new string[](8);
         cmds[0] = "npx";
         cmds[1] = "node";
         cmds[2] = filePath;
@@ -308,8 +305,6 @@ contract ChugSplash is Script, Test {
         cmds[5] = rpcUrl;
         cmds[6] = network;
         cmds[7] = privateKey;
-        cmds[8] = outPath;
-        cmds[9] = buildInfoPath;
 
         bytes memory result = vm.ffi(cmds);
         if (!silent) {
@@ -324,9 +319,7 @@ contract ChugSplash is Script, Test {
         string memory configPath,
         bool silent
     ) external returns (bytes memory) {
-        (string memory outPath, string memory buildInfoPath) = fetchPaths();
-
-        string[] memory cmds = new string[](11);
+        string[] memory cmds = new string[](9);
         cmds[0] = "npx";
         cmds[1] = "node";
         cmds[2] = filePath;
@@ -336,8 +329,6 @@ contract ChugSplash is Script, Test {
         cmds[6] = network;
         cmds[7] = privateKey;
         cmds[8] = silent == true ? "true" : "false";
-        cmds[9] = outPath;
-        cmds[10] = buildInfoPath;
 
         bytes memory result = vm.ffi(cmds);
 
@@ -369,9 +360,7 @@ contract ChugSplash is Script, Test {
     function listProposers(
         string memory configPath
     ) external returns (bytes memory) {
-        (string memory outPath, string memory buildInfoPath) = fetchPaths();
-
-        string[] memory cmds = new string[](10);
+        string[] memory cmds = new string[](8);
         cmds[0] = "npx";
         cmds[1] = "node";
         cmds[2] = filePath;
@@ -380,8 +369,6 @@ contract ChugSplash is Script, Test {
         cmds[5] = rpcUrl;
         cmds[6] = network;
         cmds[7] = privateKey;
-        cmds[8] = outPath;
-        cmds[9] = buildInfoPath;
 
         bytes memory result = vm.ffi(cmds);
         emit log(string(result));
@@ -402,9 +389,7 @@ contract ChugSplash is Script, Test {
         address newProposer,
         bool silent
     ) public returns (bytes memory) {
-        (string memory outPath, string memory buildInfoPath) = fetchPaths();
-
-        string[] memory cmds = new string[](11);
+        string[] memory cmds = new string[](9);
         cmds[0] = "npx";
         cmds[1] = "node";
         cmds[2] = filePath;
@@ -413,9 +398,7 @@ contract ChugSplash is Script, Test {
         cmds[5] = rpcUrl;
         cmds[6] = network;
         cmds[7] = privateKey;
-        cmds[8] = outPath;
-        cmds[9] = buildInfoPath;
-        cmds[10] = vm.toString(newProposer);
+        cmds[8] = vm.toString(newProposer);
 
         bytes memory result = vm.ffi(cmds);
         if (!silent) {
@@ -462,9 +445,7 @@ contract ChugSplash is Script, Test {
         address proxyAddress,
         bool silent
     ) external returns (bytes memory) {
-        (string memory outPath, string memory buildInfoPath) = fetchPaths();
-
-        string[] memory cmds = new string[](12);
+        string[] memory cmds = new string[](10);
         cmds[0] = "npx";
         cmds[1] = "node";
         cmds[2] = filePath;
@@ -474,9 +455,7 @@ contract ChugSplash is Script, Test {
         cmds[6] = network;
         cmds[7] = privateKey;
         cmds[8] = silent == true ? "true" : "false";
-        cmds[9] = outPath;
-        cmds[10] = buildInfoPath;
-        cmds[11] = vm.toString(proxyAddress);
+        cmds[9] = vm.toString(proxyAddress);
 
         bytes memory result = vm.ffi(cmds);
 
@@ -489,18 +468,13 @@ contract ChugSplash is Script, Test {
     }
 
     function getAddress(string memory _configPath, string memory _referenceName) public returns (address) {
-        (string memory outPath, string memory buildInfoPath) = fetchPaths();
-
-        string[] memory cmds = new string[](9);
+        string[] memory cmds = new string[](6);
         cmds[0] = "npx";
         cmds[1] = "node";
         cmds[2] = filePath;
         cmds[3] = "getAddress";
-        cmds[4] = rpcUrl;
-        cmds[5] = _configPath;
-        cmds[6] = _referenceName;
-        cmds[7] = outPath;
-        cmds[8] = buildInfoPath;
+        cmds[4] = _configPath;
+        cmds[5] = _referenceName;
 
         bytes memory addrBytes = vm.ffi(cmds);
         address addr;

--- a/packages/plugins/src/scripts/display-bundle-info.ts
+++ b/packages/plugins/src/scripts/display-bundle-info.ts
@@ -5,12 +5,13 @@ import hre from 'hardhat'
 import '@nomiclabs/hardhat-ethers'
 import {
   chugsplashCommitAbstractSubtask,
-  readParsedChugSplashConfig,
-  readUserChugSplashConfig,
+  readUnvalidatedChugSplashConfig,
+  readValidatedChugSplashConfig,
 } from '@chugsplash/core'
 import { utils } from 'ethers'
 
 import { getArtifactPaths } from '../hardhat/artifacts'
+import { createChugSplashRuntime } from '../utils'
 
 const chugsplashFilePath = argv[2]
 if (typeof chugsplashFilePath !== 'string') {
@@ -25,7 +26,7 @@ if (typeof chugsplashFilePath !== 'string') {
  * This makes it easy to generate bundles to be used when unit testing the ChugSplashManager.*
  */
 const displayBundleInfo = async () => {
-  const userConfig = await readUserChugSplashConfig(chugsplashFilePath)
+  const userConfig = await readUnvalidatedChugSplashConfig(chugsplashFilePath)
   const artifactPaths = await getArtifactPaths(
     hre,
     userConfig.contracts,
@@ -33,16 +34,23 @@ const displayBundleInfo = async () => {
     path.join(hre.config.paths.artifacts, 'build-info')
   )
 
-  const parsedConfig = await readParsedChugSplashConfig(
+  const cre = await createChugSplashRuntime(
+    chugsplashFilePath,
+    false,
+    true,
+    undefined
+  )
+
+  const parsedConfig = await readValidatedChugSplashConfig(
     hre.ethers.provider,
     chugsplashFilePath,
     artifactPaths,
-    'hardhat'
+    'hardhat',
+    cre
   )
 
   const { configUri, bundles } = await chugsplashCommitAbstractSubtask(
     hre.ethers.provider,
-    hre.ethers.provider.getSigner(),
     parsedConfig,
     '',
     false,

--- a/packages/plugins/src/utils.ts
+++ b/packages/plugins/src/utils.ts
@@ -1,0 +1,27 @@
+import {
+  ChugSplashRuntimeEnvironment,
+  readUnvalidatedChugSplashConfig,
+} from '@chugsplash/core'
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
+
+import { importOpenZeppelinStorageLayouts } from './hardhat/artifacts'
+
+export const createChugSplashRuntime = async (
+  configPath: string,
+  remoteExecution: boolean,
+  autoConfirm: boolean,
+  hre: HardhatRuntimeEnvironment | undefined
+): Promise<ChugSplashRuntimeEnvironment> => {
+  const userConfig = await readUnvalidatedChugSplashConfig(configPath)
+  const openzeppelinStorageLayouts = hre
+    ? await importOpenZeppelinStorageLayouts(hre, userConfig)
+    : undefined
+
+  return {
+    configPath,
+    canonicalConfigPath: hre ? hre.config.paths.canonicalConfigs : undefined,
+    remoteExecution,
+    autoConfirm,
+    openzeppelinStorageLayouts,
+  }
+}

--- a/packages/plugins/test/Transfer.spec.ts
+++ b/packages/plugins/test/Transfer.spec.ts
@@ -10,21 +10,19 @@ import hre, { ethers } from 'hardhat'
 import {
   getChugSplashManagerProxyAddress,
   chugsplashRegisterAbstractTask,
-  readParsedChugSplashConfig,
   chugsplashDeployAbstractTask,
   getEIP1967ProxyAdminAddress,
   getChugSplashManager,
   proxyTypeHashes,
-  readUserChugSplashConfig,
+  readValidatedChugSplashConfig,
+  readUnvalidatedChugSplashConfig,
 } from '@chugsplash/core'
 import { BigNumber } from 'ethers'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import * as ProxyAdminArtifact from '@openzeppelin/contracts/build/contracts/ProxyAdmin.json'
 
-import {
-  getArtifactPaths,
-  importOpenZeppelinStorageLayouts,
-} from '../src/hardhat/artifacts'
+import { createChugSplashRuntime } from '../src/utils'
+import { getArtifactPaths } from '../src/hardhat/artifacts'
 const uupsOwnableUpgradeConfigPath =
   './chugsplash/hardhat/UUPSOwnableUpgradableUpgrade.config.ts'
 const uupsAccessControlUpgradeConfigPath =
@@ -71,7 +69,7 @@ describe('Transfer', () => {
     const canonicalConfigPath = hre.config.paths.canonicalConfigs
     const deploymentFolder = hre.config.paths.deployments
 
-    const userConfig = await readUserChugSplashConfig(
+    const userConfig = await readUnvalidatedChugSplashConfig(
       transparentUpgradeConfigPath
     )
 
@@ -82,11 +80,19 @@ describe('Transfer', () => {
       path.join(hre.config.paths.artifacts, 'build-info')
     )
 
-    const parsedConfig = await readParsedChugSplashConfig(
+    const cre = await createChugSplashRuntime(
+      transparentUpgradeConfigPath,
+      false,
+      true,
+      hre
+    )
+
+    const parsedConfig = await readValidatedChugSplashConfig(
       provider,
       transparentUpgradeConfigPath,
       artifactPaths,
-      'hardhat'
+      'hardhat',
+      cre
     )
 
     await chugsplashRegisterAbstractTask(
@@ -118,11 +124,6 @@ describe('Transfer', () => {
 
     const configPath =
       './chugsplash/hardhat/TransparentUpgradableUpgrade.config.ts'
-    const openzeppelinStorageLayouts = await importOpenZeppelinStorageLayouts(
-      hre,
-      parsedConfig,
-      userConfig
-    )
 
     await chugsplashDeployAbstractTask(
       provider,
@@ -132,17 +133,14 @@ describe('Transfer', () => {
       false,
       '',
       true,
-      true,
-      true,
       signer.address,
       true,
       artifactPaths,
       canonicalConfigPath,
       deploymentFolder,
       'hardhat',
-      true,
-      hre.chugsplash.executor,
-      openzeppelinStorageLayouts
+      cre,
+      hre.chugsplash.executor
     )
 
     const TransparentUpgradableTokenV2 = await hre.chugsplash.getContract(
@@ -190,7 +188,7 @@ describe('Transfer', () => {
     const canonicalConfigPath = hre.config.paths.canonicalConfigs
     const deploymentFolder = hre.config.paths.deployments
 
-    const userConfig = await readUserChugSplashConfig(
+    const userConfig = await readUnvalidatedChugSplashConfig(
       uupsOwnableUpgradeConfigPath
     )
 
@@ -201,11 +199,19 @@ describe('Transfer', () => {
       path.join(hre.config.paths.artifacts, 'build-info')
     )
 
-    const parsedConfig = await readParsedChugSplashConfig(
+    const cre = await createChugSplashRuntime(
+      uupsOwnableUpgradeConfigPath,
+      false,
+      true,
+      hre
+    )
+
+    const parsedConfig = await readValidatedChugSplashConfig(
       provider,
       uupsOwnableUpgradeConfigPath,
       artifactPaths,
-      'hardhat'
+      'hardhat',
+      cre
     )
 
     await chugsplashRegisterAbstractTask(
@@ -232,11 +238,6 @@ describe('Transfer', () => {
 
     const configPath =
       './chugsplash/hardhat/UUPSOwnableUpgradableUpgrade.config.ts'
-    const openzeppelinStorageLayouts = await importOpenZeppelinStorageLayouts(
-      hre,
-      parsedConfig,
-      userConfig
-    )
 
     await chugsplashDeployAbstractTask(
       provider,
@@ -246,17 +247,14 @@ describe('Transfer', () => {
       false,
       '',
       true,
-      true,
-      true,
       signer.address,
       true,
       artifactPaths,
       canonicalConfigPath,
       deploymentFolder,
       'hardhat',
-      true,
-      hre.chugsplash.executor,
-      openzeppelinStorageLayouts
+      cre,
+      hre.chugsplash.executor
     )
 
     const UUPSUpgradableTokenV2 = await hre.chugsplash.getContract(
@@ -327,7 +325,7 @@ describe('Transfer', () => {
     const canonicalConfigPath = hre.config.paths.canonicalConfigs
     const deploymentFolder = hre.config.paths.deployments
 
-    const userConfig = await readUserChugSplashConfig(
+    const userConfig = await readUnvalidatedChugSplashConfig(
       uupsAccessControlUpgradeConfigPath
     )
 
@@ -338,11 +336,19 @@ describe('Transfer', () => {
       path.join(hre.config.paths.artifacts, 'build-info')
     )
 
-    const parsedConfig = await readParsedChugSplashConfig(
+    const cre = await createChugSplashRuntime(
+      uupsAccessControlUpgradeConfigPath,
+      false,
+      true,
+      hre
+    )
+
+    const parsedConfig = await readValidatedChugSplashConfig(
       provider,
       uupsAccessControlUpgradeConfigPath,
       artifactPaths,
-      'hardhat'
+      'hardhat',
+      cre
     )
 
     await chugsplashRegisterAbstractTask(
@@ -374,11 +380,6 @@ describe('Transfer', () => {
 
     const configPath =
       './chugsplash/hardhat/UUPSAccessControlUpgradableUpgrade.config.ts'
-    const openzeppelinStorageLayouts = await importOpenZeppelinStorageLayouts(
-      hre,
-      parsedConfig,
-      userConfig
-    )
 
     await chugsplashDeployAbstractTask(
       provider,
@@ -388,17 +389,14 @@ describe('Transfer', () => {
       false,
       '',
       true,
-      true,
-      true,
       signer.address,
       true,
       artifactPaths,
       canonicalConfigPath,
       deploymentFolder,
       'hardhat',
-      true,
-      hre.chugsplash.executor,
-      openzeppelinStorageLayouts
+      cre,
+      hre.chugsplash.executor
     )
 
     const UUPSAccessControlUpgradableTokenV2 = await hre.chugsplash.getContract(

--- a/packages/plugins/test/Validation.spec.ts
+++ b/packages/plugins/test/Validation.spec.ts
@@ -8,11 +8,13 @@ import '../dist'
 import { expect } from 'chai'
 import hre from 'hardhat'
 import {
-  readParsedChugSplashConfig,
-  readUserChugSplashConfig,
+  readUnvalidatedChugSplashConfig,
+  readValidatedChugSplashConfig,
 } from '@chugsplash/core'
 
 import { getArtifactPaths } from '../src/hardhat/artifacts'
+import { createChugSplashRuntime } from '../src/utils'
+
 const variableValidateConfigPath = './chugsplash/VariableValidation.config.ts'
 const constructorArgConfigPath =
   './chugsplash/ConstructorArgValidation.config.ts'
@@ -22,12 +24,11 @@ describe('Validate', () => {
   let constructorArgErr: Error
   before(async () => {
     const provider = hre.ethers.provider
-    const varValidationUserConfig = await readUserChugSplashConfig(
+    const varValidationUserConfig = await readUnvalidatedChugSplashConfig(
       variableValidateConfigPath
     )
-    const constructorArgsValidationUserConfig = await readUserChugSplashConfig(
-      constructorArgConfigPath
-    )
+    const constructorArgsValidationUserConfig =
+      await readUnvalidatedChugSplashConfig(constructorArgConfigPath)
     const varValidationArtifactPaths = await getArtifactPaths(
       hre,
       varValidationUserConfig.contracts,
@@ -41,12 +42,27 @@ describe('Validate', () => {
       path.join(hre.config.paths.artifacts, 'build-info')
     )
 
+    const creVariableValidate = await createChugSplashRuntime(
+      variableValidateConfigPath,
+      false,
+      true,
+      hre
+    )
+
+    const creConstructorArg = await createChugSplashRuntime(
+      variableValidateConfigPath,
+      false,
+      true,
+      hre
+    )
+
     try {
-      await readParsedChugSplashConfig(
+      await readValidatedChugSplashConfig(
         provider,
         variableValidateConfigPath,
         varValidationArtifactPaths,
-        'hardhat'
+        'hardhat',
+        creVariableValidate
       )
     } catch (error) {
       expect(error).to.be.an('Error')
@@ -54,11 +70,12 @@ describe('Validate', () => {
     }
 
     try {
-      await readParsedChugSplashConfig(
+      await readValidatedChugSplashConfig(
         provider,
         constructorArgConfigPath,
         constructorArgsValidationArtifactPaths,
-        'hardhat'
+        'hardhat',
+        creConstructorArg
       )
     } catch (error) {
       expect(error).to.be.an('Error')

--- a/packages/plugins/test/foundry/ChugSplash.t.sol
+++ b/packages/plugins/test/foundry/ChugSplash.t.sol
@@ -253,7 +253,7 @@ contract ChugSplashTest is Test {
 
     function testSetStringToUserDefinedTypeMapping() public {
         (Storage.UserDefinedType a) = myStorage.stringToUserDefinedMapping('testKey');
-        assertEq(Storage.UserDefinedType.unwrap(myStorage.userDefinedTypeTest()), 1000000000000000000);
+        assertEq(Storage.UserDefinedType.unwrap(a), 1000000000000000000);
     }
 
     function testSetUserDefinedTypeToStringMapping() public {


### PR DESCRIPTION
## Purpose
- Brings the rest of the config related validation into the parse config interface
- Replaces `readUserChugSpalshConfig` and `readParsedChugSplashConfig` with `readValidationChugSplashConfig` and `readUnvalidatedChugSplashConfig`
- Introduces a new global object pattern

## Global Object Pattern
In this PR, I introduce a new pattern where we initialize a set of global variables at the beginning of our tasks to avoid passing the variables through a long chain of functions. This pattern allows me to avoid doing a large refactor to make sure the `readParsedChugSplashConfig` has the necessary variables to perform the full validation. In the future, we can simplify our existing logic by adding additional variables to the global object and removing them as parameters from our functions.

This pattern does have an important tradeoff though. It is significantly less observable than our current pattern of passing everything around as function parameters. Our code often fails to compile if we make a change that breaks this web of dependencies. 

If we perpetuate the global object pattern, we will be introducing a hidden dependency and it will be on us to remember that the global object always needs to be properly defined. So this may make debugging somewhat more difficult because we will have to remember that bugs could be related to the global object. However, using the global object will allow us to significantly reduce the complexity of our functions and make our code more maintainable. 