### PR TITLE
feat(core): Add support for other openzeppelin safety check options

### DIFF
--- a/.changeset/smart-dolphins-lay.md
+++ b/.changeset/smart-dolphins-lay.md
@@ -1,0 +1,6 @@
+---
+'@chugsplash/plugins': patch
+'@chugsplash/core': patch
+---
+
+Add support for other OpenZeppelin storage safety check options

--- a/packages/contracts/contracts/interfaces/IChugSplashManager.sol
+++ b/packages/contracts/contracts/interfaces/IChugSplashManager.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+/**
+ * @title ChugSplashManager
+ * @notice Interface that must be inherited the ChugSplash manager.
+ */
+interface IChugSplashManager {
+    function activeBundleId() external returns (bytes32);
+
+    function proposers(address) external returns (bool);
+}

--- a/packages/contracts/contracts/interfaces/IChugSplashRegistry.sol
+++ b/packages/contracts/contracts/interfaces/IChugSplashRegistry.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import { IChugSplashManager } from "./IChugSplashManager.sol";
+
+/**
+ * @title ChugSplashRegistry
+ * @notice Interface that must be inherited the ChugSplash registry.
+ */
+interface IChugSplashRegistry {
+    function projects(string memory) external returns (IChugSplashManager);
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
     "@ethersproject/abstract-provider": "^5.7.0",
     "@openzeppelin/hardhat-upgrades": "^1.22.1",
     "@openzeppelin/upgrades-core": "^1.20.6",
+    "chalk": "^4.1.2",
     "core-js": "^3.27.1",
     "ethers": "^5.6.9",
     "fs": "^0.0.1-security",

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -63,7 +63,6 @@ export type ParsedConfigVariable =
 export interface UserChugSplashConfig {
   options: {
     projectName: string
-    skipStorageCheck?: boolean
   }
   contracts: UserContractConfigs
 }
@@ -74,7 +73,6 @@ export interface UserChugSplashConfig {
 export interface ParsedChugSplashConfig {
   options: {
     projectName: string
-    skipStorageCheck?: boolean
   }
   contracts: ParsedContractConfigs
 }
@@ -90,6 +88,13 @@ export type UserContractConfig = {
   previousFullyQualifiedName?: string
   variables?: UserConfigVariables
   constructorArgs?: UserConfigVariables
+  unsafeAllowRenames?: boolean
+  unsafeSkipStorageCheck?: boolean
+  unsafeAllow?: {
+    delegatecall?: boolean
+    selfdestruct?: boolean
+    missingPublicUpgradeTo?: boolean
+  }
 }
 
 export type UserContractConfigs = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -13,6 +13,8 @@ export type ChugSplashRuntimeEnvironment = {
         [referenceName: string]: any
       }
     | undefined
+  stream: NodeJS.WritableStream
+  silent: boolean
 }
 
 export type FoundryContractArtifact = {

--- a/packages/plugins/foundry-contracts/ChugSplash.sol
+++ b/packages/plugins/foundry-contracts/ChugSplash.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.15;
 // SPDX-License-Identifier: MIT
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";
-import "lib/solidity-stringutils/strings.sol";
+import "lib/solidity-stringutils/src/strings.sol";
 import "forge-std/console.sol";
 
 contract ChugSplash is Script, Test {

--- a/packages/plugins/remappings.txt
+++ b/packages/plugins/remappings.txt
@@ -1,6 +1,4 @@
 @chugsplash/=../
 @openzeppelin/contracts-upgradeable/=../contracts/node_modules/@openzeppelin/contracts-upgradeable/
 @openzeppelin/contracts/=../contracts/node_modules/@openzeppelin/contracts/
-ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
-node_modules/=node_modules/

--- a/packages/plugins/src/hardhat/artifacts.ts
+++ b/packages/plugins/src/hardhat/artifacts.ts
@@ -124,7 +124,8 @@ export const importOpenZeppelinStorageLayouts = async (
         hre,
         await hre.ethers.getContractFactory(userContractConfig.contract),
         getOpenZeppelinValidationOpts(
-          userContractConfig.externalProxyType ?? 'internal-default'
+          userContractConfig.externalProxyType ?? 'internal-default',
+          userContractConfig
         )
       )
       const storageLayout = await getStorageLayoutForAddress(

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -12,6 +12,7 @@ import {
   ChugSplashExecutorType,
   getDefaultProxyAddress,
   readUnvalidatedChugSplashConfig,
+  readValidatedChugSplashConfig,
 } from '@chugsplash/core'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 
@@ -64,7 +65,8 @@ export const deployAllChugSplashConfigs = async (
       configPath,
       remoteExecution,
       true,
-      hre
+      hre,
+      silent
     )
 
     // Skip this config if it's empty.
@@ -80,12 +82,19 @@ export const deployAllChugSplashConfigs = async (
       path.join(hre.config.paths.artifacts, 'build-info')
     )
 
+    const parsedConfig = await readValidatedChugSplashConfig(
+      hre.ethers.provider,
+      configPath,
+      artifactPaths,
+      'hardhat',
+      cre
+    )
+
     const signer = hre.ethers.provider.getSigner()
     await chugsplashDeployAbstractTask(
       hre.ethers.provider,
       hre.ethers.provider.getSigner(),
       configPath,
-      silent,
       remoteExecution,
       ipfsUrl,
       true,
@@ -96,6 +105,7 @@ export const deployAllChugSplashConfigs = async (
       deploymentFolder,
       'hardhat',
       cre,
+      parsedConfig,
       executor
     )
   }

--- a/packages/plugins/src/scripts/display-bundle-info.ts
+++ b/packages/plugins/src/scripts/display-bundle-info.ts
@@ -38,7 +38,8 @@ const displayBundleInfo = async () => {
     chugsplashFilePath,
     false,
     true,
-    undefined
+    undefined,
+    false
   )
 
   const parsedConfig = await readValidatedChugSplashConfig(

--- a/packages/plugins/src/utils.ts
+++ b/packages/plugins/src/utils.ts
@@ -10,7 +10,9 @@ export const createChugSplashRuntime = async (
   configPath: string,
   remoteExecution: boolean,
   autoConfirm: boolean,
-  hre: HardhatRuntimeEnvironment | undefined
+  hre: HardhatRuntimeEnvironment | undefined = undefined,
+  silent: boolean,
+  stream: NodeJS.WritableStream = process.stderr
 ): Promise<ChugSplashRuntimeEnvironment> => {
   const userConfig = await readUnvalidatedChugSplashConfig(configPath)
   const openzeppelinStorageLayouts = hre
@@ -23,5 +25,7 @@ export const createChugSplashRuntime = async (
     remoteExecution,
     autoConfirm,
     openzeppelinStorageLayouts,
+    stream,
+    silent,
   }
 }

--- a/packages/plugins/test/Transfer.spec.ts
+++ b/packages/plugins/test/Transfer.spec.ts
@@ -84,7 +84,8 @@ describe('Transfer', () => {
       transparentUpgradeConfigPath,
       false,
       true,
-      hre
+      hre,
+      true
     )
 
     const parsedConfig = await readValidatedChugSplashConfig(
@@ -101,8 +102,8 @@ describe('Transfer', () => {
       parsedConfig,
       false,
       signer.address,
-      true,
-      'hardhat'
+      'hardhat',
+      cre
     )
 
     const managerProxyAddress = getChugSplashManagerProxyAddress(
@@ -129,7 +130,6 @@ describe('Transfer', () => {
       provider,
       signer,
       configPath,
-      true,
       false,
       '',
       true,
@@ -140,6 +140,7 @@ describe('Transfer', () => {
       deploymentFolder,
       'hardhat',
       cre,
+      parsedConfig,
       hre.chugsplash.executor
     )
 
@@ -203,7 +204,8 @@ describe('Transfer', () => {
       uupsOwnableUpgradeConfigPath,
       false,
       true,
-      hre
+      hre,
+      true
     )
 
     const parsedConfig = await readValidatedChugSplashConfig(
@@ -220,8 +222,8 @@ describe('Transfer', () => {
       parsedConfig,
       false,
       signer.address,
-      true,
-      'hardhat'
+      'hardhat',
+      cre
     )
 
     const managerProxyAddress = getChugSplashManagerProxyAddress(
@@ -243,7 +245,6 @@ describe('Transfer', () => {
       provider,
       signer,
       configPath,
-      true,
       false,
       '',
       true,
@@ -254,6 +255,7 @@ describe('Transfer', () => {
       deploymentFolder,
       'hardhat',
       cre,
+      parsedConfig,
       hre.chugsplash.executor
     )
 
@@ -340,7 +342,8 @@ describe('Transfer', () => {
       uupsAccessControlUpgradeConfigPath,
       false,
       true,
-      hre
+      hre,
+      true
     )
 
     const parsedConfig = await readValidatedChugSplashConfig(
@@ -357,8 +360,8 @@ describe('Transfer', () => {
       parsedConfig,
       false,
       signer.address,
-      true,
-      'hardhat'
+      'hardhat',
+      cre
     )
 
     const managerProxyAddress = getChugSplashManagerProxyAddress(
@@ -385,7 +388,6 @@ describe('Transfer', () => {
       provider,
       signer,
       configPath,
-      true,
       false,
       '',
       true,
@@ -396,6 +398,7 @@ describe('Transfer', () => {
       deploymentFolder,
       'hardhat',
       cre,
+      parsedConfig,
       hre.chugsplash.executor
     )
 

--- a/packages/plugins/test/foundry/ChugSplash.t.sol
+++ b/packages/plugins/test/foundry/ChugSplash.t.sol
@@ -5,9 +5,8 @@ import "forge-std/Test.sol";
 import "../../foundry-contracts/ChugSplash.sol";
 import "../../contracts/Storage.sol";
 import { SimpleStorage } from "../../contracts/SimpleStorage.sol";
-import { ChugSplashRegistry } from "@chugsplash/contracts/contracts/ChugSplashRegistry.sol";
-import { ChugSplashManager } from "@chugsplash/contracts/contracts/ChugSplashManager.sol";
-import { Proxy } from "@chugsplash/contracts/contracts/libraries/Proxy.sol";
+import { IChugSplashRegistry } from "@chugsplash/contracts/contracts/interfaces/IChugSplashRegistry.sol";
+import { IChugSplashManager } from "@chugsplash/contracts/contracts/interfaces/IChugSplashManager.sol";
 
 /* ChugSplash Foundry Library Tests
  *
@@ -22,12 +21,12 @@ import { Proxy } from "@chugsplash/contracts/contracts/libraries/Proxy.sol";
 contract ChugSplashTest is Test {
     type UserDefinedType is uint256;
 
-    Proxy claimedProxy;
-    Proxy transferredProxy;
+    address claimedProxy;
+    address transferredProxy;
     Storage myStorage;
     SimpleStorage mySimpleStorage;
     SimpleStorage mySimpleStorage2;
-    ChugSplashRegistry registry;
+    IChugSplashRegistry registry;
     ChugSplash chugsplash;
 
     string deployConfig = "./chugsplash/foundry/deploy.t.js";
@@ -96,21 +95,21 @@ contract ChugSplashTest is Test {
         chugsplash.refresh();
 
         chugsplash.transferProxy(transferConfig, chugsplash.getAddress(transferConfig, "MySimpleStorage"), true);
-        claimedProxy = Proxy(payable(chugsplash.getAddress(claimConfig, "MySimpleStorage")));
-        transferredProxy = Proxy(payable(chugsplash.getAddress(transferConfig, "MySimpleStorage")));
+        claimedProxy = payable(chugsplash.getAddress(claimConfig, "MySimpleStorage"));
+        transferredProxy = payable(chugsplash.getAddress(transferConfig, "MySimpleStorage"));
         myStorage = Storage(chugsplash.getAddress(deployConfig, "MyStorage"));
         mySimpleStorage = SimpleStorage(chugsplash.getAddress(deployConfig, "MySimpleStorage"));
 
-        registry = ChugSplashRegistry(chugsplash.getRegistryAddress());
+        registry = IChugSplashRegistry(chugsplash.getRegistryAddress());
     }
 
     function testDidClaimProxy() public {
-        assertEq(chugsplash.getEIP1967ProxyAdminAddress(address(claimedProxy)), 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
+        assertEq(chugsplash.getEIP1967ProxyAdminAddress(claimedProxy), 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
     }
 
     function testDidTransferProxy() public {
-        ChugSplashManager manager = registry.projects(transferProjectName);
-        assertEq(chugsplash.getEIP1967ProxyAdminAddress(address(transferredProxy)), address(manager));
+        IChugSplashManager manager = registry.projects(transferProjectName);
+        assertEq(chugsplash.getEIP1967ProxyAdminAddress(transferredProxy), address(manager));
     }
 
     function testDidRegister() public {
@@ -119,23 +118,23 @@ contract ChugSplashTest is Test {
     }
 
     function testDidProposeFundApprove() public {
-        ChugSplashManager manager = registry.projects(registerProjectName);
+        IChugSplashManager manager = registry.projects(registerProjectName);
         assertTrue(address(manager).balance == 1 ether, "Manager was not funded");
         assertTrue(manager.activeBundleId() != 0, "No active bundle id detected");
     }
 
     function testDidWithdraw() public {
-        ChugSplashManager manager = registry.projects(withdrawProjectName);
+        IChugSplashManager manager = registry.projects(withdrawProjectName);
         assertTrue(address(manager).balance == 0 ether, "Manager balance not properly withdrawn");
     }
 
     function testDidCancel() public {
-        ChugSplashManager manager = registry.projects(cancelProjectName);
+        IChugSplashManager manager = registry.projects(cancelProjectName);
         assertTrue(manager.activeBundleId() == 0, "Bundle still active");
     }
 
     function testDidAddProposer() public {
-        ChugSplashManager manager = registry.projects(addProposerProjectName);
+        IChugSplashManager manager = registry.projects(addProposerProjectName);
         assertTrue(manager.proposers(newProposer));
     }
 


### PR DESCRIPTION
## Purpose
- Adds support for other openzeppelin safety check options
- Moves `silent` and `stream` parameters onto the CRE (ChugSplashRuntimeEnvironment) and uses refactors all uses of them to reference the CRE.

I also updated the `chugsplashLog` function to handle more complex outputs and used that function to output some warnings when users enable the unsafe flags. In a followup PR, I'll be updating the rest of the parsing logic to output errors using the `chugsplashLog` function to make the overall UX better. 