### PR TITLE
fix(ct): Fix incorrect fee calculation

### DIFF
--- a/.changeset/empty-bulldogs-hammer.md
+++ b/.changeset/empty-bulldogs-hammer.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/contracts': patch
+---
+
+Fix incorrect fee calculation

--- a/packages/contracts/contracts/ChugSplashManager.sol
+++ b/packages/contracts/contracts/ChugSplashManager.sol
@@ -973,7 +973,7 @@ contract ChugSplashManager is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         uint256 gasUsed = 152778 + _initialGasLeft - gasleft();
 
         uint256 executorPayment = (gasPrice * gasUsed * (100 + executorPaymentPercentage)) / 100;
-        uint256 protocolPayment = gasPrice * gasUsed * protocolPaymentPercentage;
+        uint256 protocolPayment = (gasPrice * gasUsed * (protocolPaymentPercentage)) / 100;
 
         // Add the executor's payment to the executor debt.
         totalExecutorDebt += executorPayment;

--- a/packages/plugins/chugsplash/hardhat/UUPSAccessControlUpgradableUpgrade.config.ts
+++ b/packages/plugins/chugsplash/hardhat/UUPSAccessControlUpgradableUpgrade.config.ts
@@ -22,7 +22,7 @@ const config: UserChugSplashConfig = {
         'UUPSUpgradeable:__gap': '{ gap }',
         _roles: [],
       },
-      externalProxy: '0x9A7848b9E60C7619f162880c7CA5Cbca80998034',
+      externalProxy: '0x62DB6c1678Ca81ea0d946EA3dd75b4F71421A2aE',
       externalProxyType: 'oz-access-control-uups',
       // We must specify these explicitly because newer versions of OpenZeppelin's Hardhat plugin
       // don't create the Network file in the `.openzeppelin/` folder anymore:

--- a/packages/plugins/chugsplash/hardhat/UUPSOwnableUpgradableUpgrade.config.ts
+++ b/packages/plugins/chugsplash/hardhat/UUPSOwnableUpgradableUpgrade.config.ts
@@ -21,7 +21,7 @@ const config: UserChugSplashConfig = {
         'UUPSUpgradeable:__gap': '{ gap }',
         _owner: '{ preserve }',
       },
-      externalProxy: '0xE9061F92bA9A3D9ef3f4eb8456ac9E552B3Ff5C8',
+      externalProxy: '0xA7c8B0D74b68EF10511F27e97c379FB1651e1eD2',
       externalProxyType: 'oz-ownable-uups',
       // We must specify these explicitly because newer versions of OpenZeppelin's Hardhat plugin
       // don't create the Network file in the `.openzeppelin/` folder anymore:


### PR DESCRIPTION
## Purpose
Fixes an issue where we incorrectly calculate the executor and protocol fees which causes the user to be overcharged. 

This was originally reported as an [off-chain gas estimation issue in CHU-161](https://linear.app/chugsplash/issue/CHU-161/broken-gas-estimation-and-refund).

On the topic of fees, I saw [this table on the Gelatos network fees ](https://docs.gelato.network/developer-services/relay/payment-and-fees) which is just interesting. We might want to use it to inform how to set our fees on different networks. 