### PR TITLE
fix(core): update doc for mapping value label in encoding logic

### DIFF
--- a/.changeset/new-apples-drive.md
+++ b/.changeset/new-apples-drive.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Change documentation for mapping value label

--- a/packages/core/src/languages/solidity/iterator.ts
+++ b/packages/core/src/languages/solidity/iterator.ts
@@ -184,7 +184,7 @@ export const buildMappingStorageObj = (
   const mappingValStorageObj: SolidityStorageObj = {
     astId: storageObj.astId,
     contract: storageObj.contract,
-    label: storageObj.label, // The mapping value has no storage label, which is fine since it's unused here.
+    label: storageObj.label, // The mapping value label is unused, so we just use the label of the mapping itself.
     offset: storageObj.offset,
     slot: mappingValueStorageSlotKey,
     type: variableType.value,


### PR DESCRIPTION
As of Solidity 0.8.18, mapping keys/values can have names. For example:
```
mapping(address user => uint balance) public balances;
```

This doesn't require any changes in our encoding logic, but I updated the documentation to acknowledge this new feature.