### PR TITLE
feat(ct): support rollbacks

### DIFF
--- a/.changeset/three-spies-worry.md
+++ b/.changeset/three-spies-worry.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/contracts': minor
+---
+
+Support rollbacks in the contracts

--- a/packages/contracts/contracts/ChugSplashManager.sol
+++ b/packages/contracts/contracts/ChugSplashManager.sol
@@ -471,9 +471,12 @@ contract ChugSplashManager is OwnableUpgradeable, ReentrancyGuardUpgradeable {
 
         ChugSplashBundleState storage bundle = _bundles[_bundleId];
 
+        ChugSplashBundleStatus status = bundle.status;
         require(
-            bundle.status == ChugSplashBundleStatus.PROPOSED,
-            "ChugSplashManager: bundle does not exist or has already been approved or completed"
+            status == ChugSplashBundleStatus.PROPOSED ||
+                status == ChugSplashBundleStatus.COMPLETED ||
+                status == ChugSplashBundleStatus.CANCELLED,
+            "ChugSplashManager: bundle cannot be approved"
         );
 
         require(


### PR DESCRIPTION
To support rollbacks, we now allow bundles to be approved if they've previously been completed or cancelled. 