### PR TITLE
fix(ct): Fix security vulnerability on setStorage function

### DIFF
--- a/packages/contracts/contracts/updaters/DefaultUpdater.sol
+++ b/packages/contracts/contracts/updaters/DefaultUpdater.sol
@@ -45,6 +45,10 @@ contract DefaultUpdater is ProxyUpdater {
         }
     }
 
+    function setStorage(bytes32 _key, uint8 _offset, bytes memory _segment) external ifAdmin {
+        super.setStorageValue(_key, _offset, _segment);
+    }
+
     receive() external payable {
         revert("DefaultUpdater: caller is not an admin");
     }

--- a/packages/contracts/contracts/updaters/OZUUPSUpdater.sol
+++ b/packages/contracts/contracts/updaters/OZUUPSUpdater.sol
@@ -114,6 +114,14 @@ contract OZUUPSUpdater is ProxyUpdater {
         _setImplementation(_implementation);
     }
 
+    function setStorage(
+        bytes32 _key,
+        uint8 _offset,
+        bytes memory _segment
+    ) external ifChugSplashAdmin {
+        super.setStorageValue(_key, _offset, _segment);
+    }
+
     receive() external payable {
         revert("OZUUPSUpdater: caller is not an admin");
     }

--- a/packages/contracts/contracts/updaters/ProxyUpdater.sol
+++ b/packages/contracts/contracts/updaters/ProxyUpdater.sol
@@ -47,7 +47,7 @@ abstract contract ProxyUpdater is IProxyUpdater {
      * @param _segment New value for the segment of the storage slot. The length of this value is a
      *                 bytesN value, where N is in the range [1, 32] (inclusive).
      */
-    function setStorage(bytes32 _key, uint8 _offset, bytes memory _segment) external {
+    function setStorageValue(bytes32 _key, uint8 _offset, bytes memory _segment) internal {
         bytes32 segmentBytes32 = bytes32(_segment);
 
         // If the length of the new segment equals the size of the storage slot, we can just replace

--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -1064,7 +1064,8 @@ export const parseContractConstructorArgs = (
   referenceName: string,
   abi: Array<Fragment>,
   cre: ChugSplashRuntimeEnvironment
-): ParsedConfigVariables => {
+): { args: ParsedConfigVariables; valid: boolean } => {
+  let validArguments = true
   const parsedConstructorArgs: ParsedConfigVariables = {}
 
   const constructorFragment = abi.find(
@@ -1078,7 +1079,7 @@ export const parseContractConstructorArgs = (
           `no constructor exists in the contract.`
       )
     } else {
-      return parsedConstructorArgs
+      return { args: parsedConstructorArgs, valid: validArguments }
     }
   }
 
@@ -1115,6 +1116,8 @@ export const parseContractConstructorArgs = (
         `${incorrectConstructorArgNames.map((argName) => `${argName}`)}`
       )
 
+      validArguments = false
+
       logValidationError(
         'error',
         `The following constructor arguments were found in your config for ${referenceName},\nbut are not present in the contract constructor:`,
@@ -1140,7 +1143,7 @@ export const parseContractConstructorArgs = (
     }
   }
 
-  return parsedConstructorArgs
+  return { args: parsedConstructorArgs, valid: validArguments }
 }
 
 export const assertStorageCompatiblePreserveKeywords = (

--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -1064,8 +1064,7 @@ export const parseContractConstructorArgs = (
   referenceName: string,
   abi: Array<Fragment>,
   cre: ChugSplashRuntimeEnvironment
-): { args: ParsedConfigVariables; valid: boolean } => {
-  let validArguments = true
+): ParsedConfigVariables => {
   const parsedConstructorArgs: ParsedConfigVariables = {}
 
   const constructorFragment = abi.find(
@@ -1079,7 +1078,7 @@ export const parseContractConstructorArgs = (
           `no constructor exists in the contract.`
       )
     } else {
-      return { args: parsedConstructorArgs, valid: validArguments }
+      return parsedConstructorArgs
     }
   }
 
@@ -1116,8 +1115,6 @@ export const parseContractConstructorArgs = (
         `${incorrectConstructorArgNames.map((argName) => `${argName}`)}`
       )
 
-      validArguments = false
-
       logValidationError(
         'error',
         `The following constructor arguments were found in your config for ${referenceName},\nbut are not present in the contract constructor:`,
@@ -1143,7 +1140,7 @@ export const parseContractConstructorArgs = (
     }
   }
 
-  return { args: parsedConstructorArgs, valid: validArguments }
+  return parsedConstructorArgs
 }
 
 export const assertStorageCompatiblePreserveKeywords = (


### PR DESCRIPTION
## Purpose
Fixes a vulnerability where an attacker could set arbitrary storage slots during execution. The issue is caused by the fact that the updater can be publicly available if it takes more than one block to execute a deployment. So we need to have logic on the setStorage function which prevents some arbitrary third party from calling it. 

This vulnerability was handled when we introduced the Updater pattern by introducing the ChugSplashAdmin and restricting access to the setStorage function to only proxy admins or ChugSplash admins depending on the proxy type. The vulnerability appears to have been reintroduced when a change was made to how we handle the setStorage action.

I resolved the issue by moving the ChugSplashAdmin logic onto the base ProxyUpdater and using it to secure the setStorage action for both updater types. This also involved adding some additional logic to the adapters ensuring that the initiate and complete functions are called for all proxy types because those functions are used to set and unset the ChugSplashAdmin at the beginning and end of execution. 