### PR TITLE
fix(core): restrict solidity versions to >0.5.x

### DIFF
--- a/.changeset/slimy-mugs-search.md
+++ b/.changeset/slimy-mugs-search.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Restrict Solidity versions to >0.5.x

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -736,7 +736,7 @@ export const readBuildInfo = (buildInfoPath: string): BuildInfo => {
     fs.readFileSync(buildInfoPath, 'utf8')
   )
 
-  if (!semver.satisfies(buildInfo.solcVersion, '>=0.4.x <0.9.x')) {
+  if (!semver.satisfies(buildInfo.solcVersion, '>0.5.x <0.9.x')) {
     throw new Error(
       `Storage layout for Solidity version ${buildInfo.solcVersion} not yet supported. Sorry!`
     )


### PR DESCRIPTION
OpenZeppelin's solidity-ast library, which we use throughout our codebase, hasn't been tested thoroughly for Solidity versions before 0.6.0. [Here's the link](https://github.com/OpenZeppelin/solidity-ast#solidity-versioning).