### PR TITLE
fix(core): Fix initializeChugSplash failure on network where contracts are already deployed

### DIFF
--- a/packages/core/src/languages/solidity/predeploys.ts
+++ b/packages/core/src/languages/solidity/predeploys.ts
@@ -69,12 +69,22 @@ export const initializeChugSplash = async (
   logger?.info('[ChugSplash]: deployed ChugSplashRegistry')
   logger?.info('[ChugSplash]: initializing ChugSplashRegistry...')
 
-  await (
-    await ChugSplashRegistry.initialize(
-      executors,
-      await getGasPriceOverrides(provider)
-    )
-  ).wait()
+  try {
+    await (
+      await ChugSplashRegistry.initialize(
+        executors,
+        await getGasPriceOverrides(provider)
+      )
+    ).wait()
+  } catch (err) {
+    if (
+      err.message.includes('Initializable: contract is already initialized')
+    ) {
+      logger?.info('[ChugSplash]: registry was already initialized')
+    } else {
+      throw err
+    }
+  }
 
   for (const executorAddress of executors) {
     assert(


### PR DESCRIPTION
## Purpose
Fixes a bug introduced in #583 where attempting to deploy the ChugSplash contracts against a network where they are already deployed will cause the program to cash. This prevents us from doing deployments against local networks and will also prevent us from spinning up executors against networks where the contracts have already been deployed. 