### PR TITLE
fix(core): fix a couple bugs when deploying no-proxy contracts

### DIFF
--- a/.changeset/wet-lobsters-accept.md
+++ b/.changeset/wet-lobsters-accept.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Fixes a couple errors when deploying no-proxy contracts

--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -933,7 +933,10 @@ const parseContractVariables = (
   cre: ChugSplashRuntimeEnvironment
 ): ParsedConfigVariables => {
   const parsedConfigVariables: ParsedConfigVariables = {}
-  if (!contractConfig.variables) {
+  if (
+    !contractConfig.variables ||
+    Object.keys(contractConfig.variables).length === 0
+  ) {
     return {}
   }
 

--- a/packages/core/src/languages/solidity/storage.ts
+++ b/packages/core/src/languages/solidity/storage.ts
@@ -627,6 +627,10 @@ export const computeStorageSegments = (
   contractConfig: ParsedContractConfig,
   dereferencer: ASTDereferencer
 ): Array<StorageSlotSegment> => {
+  if (contractConfig.kind === 'no-proxy') {
+    return []
+  }
+
   let segments: StorageSlotSegment[] = []
   for (const storageObj of Object.values(extendedLayout.storage)) {
     const configVarValue = contractConfig.variables[storageObj.configVarName]


### PR DESCRIPTION
Fixes two bugs discovered when deploying a `no-proxy` contract.

First bug:
Encoding error resulted from calling `chugsplash-deploy` on the demo contract as a `no-proxy` kind without a `variables` field.

Second bug:
Parsing error resulted from the same situation as above, except with `variables: {}` in the `no-proxy` contract.