### PR TITLE
Spec: Add Constructor Arg Specification

### DIFF
--- a/packages/plugins/test/ManagerUpgrade.spec.ts
+++ b/packages/plugins/test/ManagerUpgrade.spec.ts
@@ -1,3 +1,5 @@
+import '@nomiclabs/hardhat-ethers'
+
 import hre, { chugsplash } from 'hardhat'
 import { Contract } from 'ethers'
 import {
@@ -8,8 +10,6 @@ import {
   ChugSplashManagerProxyArtifact,
   OWNER_MULTISIG_ADDRESS,
 } from '@chugsplash/contracts'
-import '@nomiclabs/hardhat-ethers'
-
 import { expect } from 'chai'
 
 import { orgId } from '../chugsplash/Storage.config'


### PR DESCRIPTION
## Purpose
Completes the specification of the ChugSplash config file including:
- Specification for the constructor arguments
- Specification for the other input options

Also fixes a minor issue with the plugin package tests.