### PR TITLE
maint(ct): Add Slither and solhint prettier plugin to contracts package

### DIFF
--- a/packages/contracts/.solhint.json
+++ b/packages/contracts/.solhint.json
@@ -7,12 +7,14 @@
     "code-complexity": ["warn", 5],
     "max-line-length": ["error", 100],
     "func-param-name-mixedcase": "error",
+    "func-name-mixedcase": "off",
     "modifier-name-mixedcase": "error",
     "ordering": "warn",
+    "avoid-low-level-calls": "off",
+    "no-inline-assembly": "off",
+    "no-empty-blocks": "off",
     "not-rely-on-time": "off",
-    "no-complex-fallback": "off",
-    "not-rely-on-block-hash": "off",
-    "reentrancy": "off",
-    "contract-name-camelcase": "off"
+    "var-name-mixedcase": "off",
+    "func-visibility": ["warn", { "ignoreConstructors": true }]
   }
 }

--- a/packages/contracts/.solhintignore
+++ b/packages/contracts/.solhintignore
@@ -1,1 +1,3 @@
+# Deps and test files
 node_modules
+test/*.t.sol

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -15,13 +15,14 @@
     "build:contracts": "hardhat clean && hardhat compile",
     "clean": "rimraf dist/ ./tsconfig.tsbuildinfo",
     "test:coverage": "forge test",
+    "slither": "./scripts/slither.sh",
     "lint": "yarn lint:fix && yarn lint:check",
     "lint:check": "yarn lint:contracts:check && yarn lint:ts:check",
     "lint:fix": "yarn lint:contracts:fix && yarn lint:ts:fix",
     "lint:ts:check": "eslint .",
     "lint:ts:fix": "yarn lint:ts:check --fix",
-    "lint:contracts:check": "yarn solhint -f table '{contracts,test}/**/*.sol'",
-    "lint:contracts:fix": "prettier --write '{contracts,test}/**/*.sol'",
+    "lint:contracts:check": "yarn solhint -f table 'contracts/**/*.sol' && yarn prettier --check 'contracts/**/*.sol'",
+    "lint:contracts:fix": "yarn solhint --fix '{contracts,test}/**/*.sol' && yarn prettier --write '{contracts,test}/**/*.sol'",
     "pre-commit": "lint-staged"
   },
   "homepage": "https://github.com/smartcontracts/chugsplash/tree/develop/packages/contracts#readme",
@@ -40,7 +41,7 @@
     "ethers": "^5.6.9",
     "forge-std": "https://github.com/foundry-rs/forge-std#2a2ce3692b8c1523b29de3ec9d961ee9fbbc43a6",
     "hardhat": "^2.9.9",
-    "solhint": "^3.3.6",
+    "solhint": "^3.4.1",
     "solhint-plugin-prettier": "^0.0.5"
   }
 }

--- a/packages/contracts/scripts/slither.sh
+++ b/packages/contracts/scripts/slither.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Sourced from the Optimism Monorepo
+# https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/scripts/slither.sh
+
+rm -rf artifacts forge-artifacts
+
+# See slither.config.json for slither settings
+if [[ -z "$TRIAGE_MODE" ]]; then
+  echo "Running slither"
+  slither .
+else
+  echo "Running slither in triage mode"
+  # Slither's triage mode will run an 'interview' in the terminal, allowing you to review each of
+  # its findings, and specify which should be ignored in future runs of slither. This will update
+  # (or create) the slither.db.json file. This DB is a cleaner alternative to adding slither-disable
+  # comments throughout the codebase.
+  # Triage mode should only be run manually, and can be used to update the db when new findings are
+  # causing a CI failure.
+  slither . --triage-mode
+
+  # For whatever reason the slither db contains a filename_absolute property which includes the full
+  # local path to source code on the machine where it was generated. This property does not
+  # seem to be required for slither to run, so we remove it.
+  DB=slither.db.json
+  TEMP_DB=temp-slither.db.json
+  mv $DB $TEMP_DB
+  jq 'walk(if type == "object" then del(.filename_absolute) else . end)' $TEMP_DB > $DB
+  rm -f $TEMP_DB
+fi

--- a/packages/contracts/slither.config.json
+++ b/packages/contracts/slither.config.json
@@ -1,0 +1,12 @@
+{
+  "fail_low": true,
+  "fail_pedantic": true,
+  "exclude_optimization": true,
+  "exclude_informational": true,
+  "solc_disable_warnings": false,
+  "hardhat_ignore_compile": false,
+  "disable_color": false,
+  "exclude_dependencies": true,
+  "filter_paths": "test,node_modules",
+  "foundry_out_directory": "forge-artifacts"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7748,7 +7748,7 @@ solhint-plugin-prettier@^0.0.5:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-solhint@^3.3.6:
+solhint@^3.3.6, solhint@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.4.1.tgz#8ea15b21c13d1be0b53fd46d605a24d0b36a0c46"
   integrity sha512-pzZn2RlZhws1XwvLPVSsxfHrwsteFf5eySOhpAytzXwKQYbTCJV6z8EevYDiSVKMpWrvbKpEtJ055CuEmzp4Xg==


### PR DESCRIPTION
## Purpose
Adds Slither and solhint prettier plugin to the contracts package with the same configuration as the Optimism monorepo.

Note: This does not enable Slither during the CI process as there are quite a few errors and warnings from it that we may want to address first. I've created a separate ticket to do that. 