### PR TITLE
maint(ct): Add Semver to ChugSplashManager

### DIFF
--- a/.changeset/curly-cycles-collect.md
+++ b/.changeset/curly-cycles-collect.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/contracts': patch
+---
+
+Add Semver versioning to ChugSplashManager

--- a/packages/contracts/contracts/ChugSplashManager.sol
+++ b/packages/contracts/contracts/ChugSplashManager.sol
@@ -23,11 +23,13 @@ import {
     ReentrancyGuardUpgradeable
 } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import { Semver } from "@eth-optimism/contracts-bedrock/contracts/universal/Semver.sol";
 
 /**
  * @title ChugSplashManager
  */
-contract ChugSplashManager is OwnableUpgradeable, ReentrancyGuardUpgradeable {
+
+contract ChugSplashManager is OwnableUpgradeable, ReentrancyGuardUpgradeable, Semver {
     /**
      * @notice Emitted when a ChugSplash bundle is proposed.
      *
@@ -288,8 +290,11 @@ contract ChugSplashManager is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         uint256 _executionLockTime,
         uint256 _ownerBondAmount,
         uint256 _executorPaymentPercentage,
-        uint256 _protocolPaymentPercentage
-    ) {
+        uint256 _protocolPaymentPercentage,
+        uint _major,
+        uint _minor,
+        uint _patch
+    ) Semver(_major, _minor, _patch) {
         registry = _registry;
         executionLockTime = _executionLockTime;
         ownerBondAmount = _ownerBondAmount;

--- a/packages/contracts/contracts/ChugSplashManagerProxy.sol
+++ b/packages/contracts/contracts/ChugSplashManagerProxy.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.9;
 import { Proxy } from "@eth-optimism/contracts-bedrock/contracts/universal/Proxy.sol";
 import { ChugSplashRegistry } from "./ChugSplashRegistry.sol";
 import { IChugSplashManager } from "./interfaces/IChugSplashManager.sol";
-import { IChugSplashRegistry } from "./interfaces/IChugSplashRegistry.sol";
 
 /**
  * @title ChugSplashManagerProxy
@@ -36,7 +35,7 @@ contract ChugSplashManagerProxy is Proxy {
 
     modifier isApprovedImplementation(address _implementation) {
         require(
-            registry.versions(_implementation) == true,
+            registry.managerImplementations(_implementation) == true,
             "ChugSplashManagerProxy: unapproved manager"
         );
         _;

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -72,12 +72,21 @@ export const CHUGSPLASH_REGISTRY_ADDRESS = utils.getCreate2Address(
   )
 )
 
+export const CURRENT_CHUGSPLASH_MANAGER_VERSION = {
+  major: 1,
+  minor: 0,
+  patch: 0,
+}
+
 export const managerConstructorValues = [
   CHUGSPLASH_REGISTRY_ADDRESS,
   EXECUTION_LOCK_TIME,
   OWNER_BOND_AMOUNT.toString(),
   EXECUTOR_PAYMENT_PERCENTAGE,
   PROTOCOL_PAYMENT_PERCENTAGE,
+  CURRENT_CHUGSPLASH_MANAGER_VERSION.major,
+  CURRENT_CHUGSPLASH_MANAGER_VERSION.minor,
+  CURRENT_CHUGSPLASH_MANAGER_VERSION.patch,
 ]
 
 const [managerConstructorFragment] = ChugSplashManagerABI.filter(

--- a/packages/core/src/languages/solidity/predeploys.ts
+++ b/packages/core/src/languages/solidity/predeploys.ts
@@ -41,6 +41,7 @@ import {
 } from '../../utils'
 import {
   CHUGSPLASH_CONSTRUCTOR_ARGS,
+  CURRENT_CHUGSPLASH_MANAGER_VERSION,
   CHUGSPLASH_REGISTRY_ADDRESS,
   managerConstructorValues,
   registryConstructorValues,
@@ -88,6 +89,9 @@ export const initializeChugSplash = async (
     await (
       await ChugSplashRegistry.initialize(
         ChugSplashManager.address,
+        CURRENT_CHUGSPLASH_MANAGER_VERSION.major,
+        CURRENT_CHUGSPLASH_MANAGER_VERSION.minor,
+        CURRENT_CHUGSPLASH_MANAGER_VERSION.patch,
         executors,
         await getGasPriceOverrides(provider)
       )

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -57,7 +57,7 @@ import {
 } from './config/types'
 import { ChugSplashActionBundle, ChugSplashActionType } from './actions/types'
 import {
-  CHUGSPLASH_MANAGER_V1_ADDRESS,
+  CURRENT_CHUGSPLASH_MANAGER_VERSION,
   CHUGSPLASH_REGISTRY_ADDRESS,
   Integration,
 } from './constants'
@@ -241,7 +241,9 @@ export const claimChugSplashProject = async (
       await ChugSplashRegistry.claim(
         organizationID,
         newOwnerAddress,
-        CHUGSPLASH_MANAGER_V1_ADDRESS,
+        CURRENT_CHUGSPLASH_MANAGER_VERSION.major,
+        CURRENT_CHUGSPLASH_MANAGER_VERSION.minor,
+        CURRENT_CHUGSPLASH_MANAGER_VERSION.patch,
         initializerData,
         await getGasPriceOverrides(provider)
       )

--- a/packages/plugins/test/ManagerUpgrade.spec.ts
+++ b/packages/plugins/test/ManagerUpgrade.spec.ts
@@ -26,7 +26,7 @@ describe('Manager Upgrade', () => {
       '0x10000000000000000000',
     ])
     const registry = await getChugSplashRegistry(signer)
-    await registry.setVersion(Stateless.address, true)
+    await registry.setVersion(Stateless.address, 2, 0, 0)
   })
 
   it('does upgrade chugsplash manager', async () => {


### PR DESCRIPTION
## Purpose
- Adds Semver versioning to the ChugSplashManager
- Renames some variables throughout the codebase to make the manager versioning more clear.
- Updates the `managers` and `projects` mappings in the registry to use the `ChugSplashManagerProxy` contract type instead of the `ChugSplashManager` contract type which simplifies things a bit and makes the use of a proxy in front of the managers a bit more clear. 