### PR TITLE
maint(ct): move managed service functions out of registry

### DIFF
--- a/packages/contracts/contracts/ManagedService.sol
+++ b/packages/contracts/contracts/ManagedService.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.9;
 
 import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
 
-contract PermissionedCaller is AccessControl {
+contract ManagedService is AccessControl {
     event ExecutedCall(address indexed from, address indexed to, uint256 value);
 
-    bytes32 public constant PERMISSIONED_CALLER_ROLE = keccak256("PERMISSIONED_CALLER_ROLE");
+    bytes32 public constant CALLER_ROLE = keccak256("CALLER_ROLE");
 
     constructor(address _owner) {
         _grantRole(bytes32(0), _owner);
@@ -15,7 +15,7 @@ contract PermissionedCaller is AccessControl {
     function executeCall(
         address _to,
         bytes memory _data
-    ) external payable onlyRole(PERMISSIONED_CALLER_ROLE) returns (bytes memory) {
+    ) external payable onlyRole(CALLER_ROLE) returns (bytes memory) {
         (bool success, bytes memory returnData) = _to.call{ value: msg.value }(_data);
         require(success, "PermissionedCaller: call failed");
         emit ExecutedCall(msg.sender, _to, msg.value);

--- a/packages/contracts/src/ifaces.ts
+++ b/packages/contracts/src/ifaces.ts
@@ -5,6 +5,7 @@ import path from 'path'
 export const ChugSplashRegistryArtifact = require('../artifacts/contracts/ChugSplashRegistry.sol/ChugSplashRegistry.json')
 export const ChugSplashManagerArtifact = require('../artifacts/contracts/ChugSplashManager.sol/ChugSplashManager.json')
 export const ChugSplashManagerProxyArtifact = require('../artifacts/contracts/ChugSplashManagerProxy.sol/ChugSplashManagerProxy.json')
+export const ManagedServiceArtifact = require('../artifacts/contracts/ManagedService.sol/ManagedService.json')
 export const ProxyArtifact = require('../artifacts/@eth-optimism/contracts-bedrock/contracts/universal/Proxy.sol/Proxy.json')
 export const DefaultUpdaterArtifact = require('../artifacts/contracts/updaters/DefaultUpdater.sol/DefaultUpdater.json')
 export const OZUUPSUpdaterArtifact = require('../artifacts/contracts/updaters/OZUUPSUpdater.sol/OZUUPSUpdater.json')
@@ -25,6 +26,8 @@ export const buildInfo = require(`../artifacts/build-info/${fileNames[0]}`)
 
 export const ChugSplashRegistryABI = ChugSplashRegistryArtifact.abi
 export const ChugSplashManagerABI = ChugSplashManagerArtifact.abi
+export const ChugSplashManagerProxyABI = ChugSplashManagerProxyArtifact.abi
+export const ManagedServiceABI = ManagedServiceArtifact.abi
 export const ProxyABI = ProxyArtifact.abi
 export const DefaultUpdaterABI = DefaultUpdaterArtifact.abi
 export const DefaultAdapterABI = DefaultAdapterArtifact.abi

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -16,6 +16,7 @@ import {
   OZ_UUPS_UPDATER_ADDRESS,
   OWNER_MULTISIG_ADDRESS,
   ChugSplashRegistryABI,
+  ManagedServiceArtifact,
   ChugSplashManagerABI,
 } from '@chugsplash/contracts'
 import { utils, constants } from 'ethers'
@@ -38,6 +39,8 @@ export const keywords: Keywords = {
   gap: '{gap}',
 }
 
+export const EXECUTOR_ROLE = utils.keccak256(utils.toUtf8Bytes('EXECUTOR_ROLE'))
+
 const chugsplashRegistrySourceName = ChugSplashRegistryArtifact.sourceName
 const chugsplashManagerSourceName = ChugSplashManagerArtifact.sourceName
 const defaultAdapterSourceName = DefaultAdapterArtifact.sourceName
@@ -55,6 +58,18 @@ const [registryConstructorFragment] = ChugSplashRegistryABI.filter(
 )
 const registryConstructorArgTypes = registryConstructorFragment.inputs.map(
   (input) => input.type
+)
+
+export const MANAGED_SERVICE_ADDRESS = utils.getCreate2Address(
+  DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
+  constants.HashZero,
+  utils.solidityKeccak256(
+    ['bytes', 'bytes'],
+    [
+      ManagedServiceArtifact.bytecode,
+      utils.defaultAbiCoder.encode(['address'], [OWNER_MULTISIG_ADDRESS]),
+    ]
+  )
 )
 
 export const CHUGSPLASH_REGISTRY_ADDRESS = utils.getCreate2Address(
@@ -80,6 +95,7 @@ export const CURRENT_CHUGSPLASH_MANAGER_VERSION = {
 
 export const managerConstructorValues = [
   CHUGSPLASH_REGISTRY_ADDRESS,
+  MANAGED_SERVICE_ADDRESS,
   EXECUTION_LOCK_TIME,
   OWNER_BOND_AMOUNT.toString(),
   EXECUTOR_PAYMENT_PERCENTAGE,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1296,3 +1296,13 @@ export const isLiveNetwork = async (
   const network = await provider.getNetwork()
   return network.name !== 'unknown'
 }
+
+export const getImpersonatedSigner = async (
+  address: string,
+  provider: providers.JsonRpcProvider
+): Promise<providers.JsonRpcSigner> => {
+  // This RPC method works for anvil too, since it's an alias for 'anvil_impersonateAccount'.
+  await provider.send('hardhat_impersonateAccount', [address])
+
+  return provider.getSigner(address)
+}

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -141,12 +141,7 @@ export class ChugSplashExecutor extends BaseServiceV2<
     }
 
     // Deploy the ChugSplash contracts.
-    await initializeChugSplash(
-      this.state.provider,
-      wallet,
-      executorAddresses,
-      this.logger
-    )
+    await initializeChugSplash(this.state.provider, wallet, this.logger)
 
     this.logger.info('[ChugSplash]: finished setting up chugsplash')
 

--- a/packages/plugins/src/foundry/index.ts
+++ b/packages/plugins/src/foundry/index.ts
@@ -761,8 +761,7 @@ const command = args[0]
 
       const provider = new ethers.providers.JsonRpcProvider(rpcUrl, network)
       const wallet = new ethers.Wallet(privateKey, provider)
-      const walletAddress = await wallet.getAddress()
-      await initializeChugSplash(provider, wallet, [walletAddress])
+      await initializeChugSplash(provider, wallet)
       break
     }
   }

--- a/packages/plugins/src/hardhat/tasks.ts
+++ b/packages/plugins/src/hardhat/tasks.ts
@@ -38,7 +38,7 @@ import {
   readUnvalidatedChugSplashConfig,
   isLiveNetwork,
 } from '@chugsplash/core'
-import { ChugSplashManagerABI, EXECUTOR } from '@chugsplash/contracts'
+import { ChugSplashManagerABI } from '@chugsplash/contracts'
 import ora from 'ora'
 import * as dotenv from 'dotenv'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
@@ -144,7 +144,7 @@ export const chugsplashDeployTask = async (
   const provider = hre.ethers.provider
   const signer = hre.ethers.provider.getSigner()
   const signerAddress = await signer.getAddress()
-  await initializeChugSplash(hre.ethers.provider, signer, [signerAddress])
+  await initializeChugSplash(hre.ethers.provider, signer)
 
   const canonicalConfigPath = hre.config.paths.canonicalConfigs
   const deploymentFolder = hre.config.paths.deployments
@@ -214,8 +214,7 @@ export const chugsplashClaimTask = async (
 
   const provider = hre.ethers.provider
   const signer = hre.ethers.provider.getSigner()
-  const signerAddress = await signer.getAddress()
-  await initializeChugSplash(hre.ethers.provider, signer, [signerAddress])
+  await initializeChugSplash(hre.ethers.provider, signer)
 
   const userConfig = await readUnvalidatedChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
@@ -287,8 +286,7 @@ export const chugsplashProposeTask = async (
 
   const provider = hre.ethers.provider
   const signer = hre.ethers.provider.getSigner()
-  const signerAddress = await signer.getAddress()
-  await initializeChugSplash(hre.ethers.provider, signer, [signerAddress])
+  await initializeChugSplash(hre.ethers.provider, signer)
 
   const artifactPaths = await getArtifactPaths(
     hre,
@@ -357,8 +355,8 @@ export const chugsplashApproveTask = async (
   const userConfig = await readUnvalidatedChugSplashConfig(configPath)
   const provider = hre.ethers.provider
   const signer = hre.ethers.provider.getSigner()
-  const signerAddress = await signer.getAddress()
-  await initializeChugSplash(hre.ethers.provider, signer, [signerAddress])
+
+  await initializeChugSplash(hre.ethers.provider, signer)
 
   const deploymentFolder = hre.config.paths.deployments
   const artifactPaths = await getArtifactPaths(
@@ -404,8 +402,8 @@ subtask(TASK_CHUGSPLASH_LIST_ALL_PROJECTS)
   .setDescription('Lists all existing ChugSplash projects')
   .setAction(async (_, hre) => {
     const signer = hre.ethers.provider.getSigner()
-    const signerAddress = await signer.getAddress()
-    await initializeChugSplash(hre.ethers.provider, signer, [signerAddress])
+
+    await initializeChugSplash(hre.ethers.provider, signer)
 
     const ChugSplashRegistry = getChugSplashRegistry(
       hre.ethers.provider.getSigner()
@@ -496,8 +494,8 @@ subtask(TASK_CHUGSPLASH_LIST_BUNDLES)
       hre
     ) => {
       const signer = hre.ethers.provider.getSigner()
-      const signerAddress = await signer.getAddress()
-      await initializeChugSplash(hre.ethers.provider, signer, [signerAddress])
+
+      await initializeChugSplash(hre.ethers.provider, signer)
 
       const ChugSplashRegistry = getChugSplashRegistry(signer)
 
@@ -627,8 +625,8 @@ export const monitorTask = async (
 
   const provider = hre.ethers.provider
   const signer = hre.ethers.provider.getSigner()
-  const signerAddress = await signer.getAddress()
-  await initializeChugSplash(hre.ethers.provider, signer, [signerAddress])
+
+  await initializeChugSplash(hre.ethers.provider, signer)
 
   const deploymentFolder = hre.config.paths.deployments
   const userConfig = await readUnvalidatedChugSplashConfig(configPath)
@@ -692,8 +690,8 @@ export const chugsplashFundTask = async (
 
   const provider = hre.ethers.provider
   const signer = hre.ethers.provider.getSigner()
-  const signerAddress = await signer.getAddress()
-  await initializeChugSplash(hre.ethers.provider, signer, [signerAddress])
+
+  await initializeChugSplash(hre.ethers.provider, signer)
 
   const userConfig = await readUnvalidatedChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
@@ -761,8 +759,8 @@ task(TASK_NODE)
         spinner.start('Booting up ChugSplash...')
 
         const signer = hre.ethers.provider.getSigner()
-        const signerAddress = await signer.getAddress()
-        await initializeChugSplash(hre.ethers.provider, signer, [signerAddress])
+
+        await initializeChugSplash(hre.ethers.provider, signer)
 
         spinner.succeed('ChugSplash has been initialized.')
 
@@ -814,7 +812,6 @@ task(TASK_TEST)
       const liveNetwork = await isLiveNetwork(hre.ethers.provider)
 
       const signer = hre.ethers.provider.getSigner()
-      const executor = liveNetwork ? EXECUTOR : await signer.getAddress()
       const networkName = await resolveNetworkName(
         hre.ethers.provider,
         'hardhat'
@@ -835,7 +832,7 @@ task(TASK_TEST)
             throw new Error('Snapshot failed to be reverted.')
           }
         } catch {
-          await initializeChugSplash(hre.ethers.provider, signer, [executor])
+          await initializeChugSplash(hre.ethers.provider, signer)
           if (!noCompile) {
             await hre.run(TASK_COMPILE, {
               quiet: true,
@@ -880,13 +877,11 @@ task(TASK_RUN)
       runSuper
     ) => {
       const { deployAll, noCompile } = args
-      const liveNetwork = await isLiveNetwork(hre.ethers.provider)
 
       if (deployAll) {
         const signer = hre.ethers.provider.getSigner()
 
-        const executor = liveNetwork ? EXECUTOR : await signer.getAddress()
-        await initializeChugSplash(hre.ethers.provider, signer, [executor])
+        await initializeChugSplash(hre.ethers.provider, signer)
         if (!noCompile) {
           await hre.run(TASK_COMPILE, {
             quiet: true,


### PR DESCRIPTION
We now use `AccessControl` in the `ManagedService` contract to keep track of executors, managed service proposers, and protocol payment recipients. This functionality was removed from the registry to make it as minimal as possible, since it won't be upgraded in the future.

Also, this PR removes the `initializer` function in the registry in favor of calling setter functions, like `setVersion`. This is because the `initializer` function could be called by anyone when the registry is initially deployed, which is a security hazard. We could add an `onlyOwner` modifier to the `initializer`, but at that point the logic seems redundant.

Since the registry must be initialized by the owner, this PR also updates the off-chain `initializeChugSplash` function to impersonate the multisig owner on local networks.