### PR TITLE
maint(ct): check the manager's semver version in the registry's  function

### DIFF
--- a/packages/contracts/contracts/ChugSplashManager.sol
+++ b/packages/contracts/contracts/ChugSplashManager.sol
@@ -24,7 +24,7 @@ import {
 } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
-import { Semver } from "@eth-optimism/contracts-bedrock/contracts/universal/Semver.sol";
+import { Semver } from "./Semver.sol";
 
 /**
  * @title ChugSplashManager

--- a/packages/contracts/contracts/ChugSplashRegistry.sol
+++ b/packages/contracts/contracts/ChugSplashRegistry.sol
@@ -5,6 +5,7 @@ import { ChugSplashManagerProxy } from "./ChugSplashManagerProxy.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { IChugSplashManager } from "./interfaces/IChugSplashManager.sol";
+import { Version } from "./Semver.sol";
 
 /**
  * @title ChugSplashRegistry
@@ -66,6 +67,13 @@ contract ChugSplashRegistry is Ownable, Initializable {
      * @param adapter   Address of the adapter for the proxy.
      */
     event ContractKindAdded(bytes32 contractKindHash, address adapter);
+
+    event VersionAdded(
+        uint256 indexed major,
+        uint256 indexed minor,
+        uint256 indexed patch,
+        address manager
+    );
 
     /**
      * @notice Mapping of claimers to project names to ChugSplashManagerProxy contracts.
@@ -195,18 +203,20 @@ contract ChugSplashRegistry is Ownable, Initializable {
         emit ContractKindAdded(_contractKindHash, _adapter);
     }
 
-    function setVersion(
-        address _version,
-        uint _major,
-        uint _minor,
-        uint _patch
-    ) external onlyOwner {
+    function addVersion(address _manager) external onlyOwner {
+        Version memory version = IChugSplashManager(_manager).version();
+        uint256 major = version.major;
+        uint256 minor = version.minor;
+        uint256 patch = version.patch;
+
         require(
-            versions[_major][_minor][_patch] == address(0),
+            versions[major][minor][patch] == address(0),
             "ChugSplashRegistry: version already set"
         );
 
-        managerImplementations[_version] = true;
-        versions[_major][_minor][_patch] = _version;
+        managerImplementations[_manager] = true;
+        versions[major][minor][patch] = _manager;
+
+        emit VersionAdded(major, minor, patch, _manager);
     }
 }

--- a/packages/contracts/contracts/Semver.sol
+++ b/packages/contracts/contracts/Semver.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+struct Version {
+    uint256 major;
+    uint256 minor;
+    uint256 patch;
+}
+
+/**
+ * @title Semver
+ * @notice Semver is a simple contract for managing contract versions.
+ */
+contract Semver {
+    /**
+     * @notice Contract version number (major).
+     */
+    uint256 private immutable MAJOR_VERSION;
+
+    /**
+     * @notice Contract version number (minor).
+     */
+    uint256 private immutable MINOR_VERSION;
+
+    /**
+     * @notice Contract version number (patch).
+     */
+    uint256 private immutable PATCH_VERSION;
+
+    /**
+     * @param _major Version number (major).
+     * @param _minor Version number (minor).
+     * @param _patch Version number (patch).
+     */
+    constructor(uint256 _major, uint256 _minor, uint256 _patch) {
+        MAJOR_VERSION = _major;
+        MINOR_VERSION = _minor;
+        PATCH_VERSION = _patch;
+    }
+
+    /**
+     * @notice Returns the full semver contract version.
+     *
+     * @return Semver contract version as a tuple.
+     */
+    function version() public view returns (Version memory) {
+        return Version(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION);
+    }
+}

--- a/packages/contracts/contracts/interfaces/IChugSplashManager.sol
+++ b/packages/contracts/contracts/interfaces/IChugSplashManager.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
+import { Version } from "../Semver.sol";
+
 /**
  * @title ChugSplashManager
  * @notice Interface that must be inherited the ChugSplash manager.
@@ -13,4 +15,6 @@ interface IChugSplashManager {
     function isExecuting() external view returns (bool);
 
     function initialize(bytes memory) external;
+
+    function version() external view returns (Version memory);
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -22,7 +22,7 @@
     "lint:ts:check": "eslint .",
     "lint:ts:fix": "yarn lint:ts:check --fix",
     "lint:contracts:check": "yarn solhint -f table 'contracts/**/*.sol' && yarn prettier --check 'contracts/**/*.sol'",
-    "lint:contracts:fix": "yarn solhint --fix '{contracts,test}/**/*.sol' && yarn prettier --write '{contracts,test}/**/*.sol'",
+    "lint:contracts:fix": "yarn prettier --write '{contracts,test}/**/*.sol' && yarn solhint --fix '{contracts,test}/**/*.sol'",
     "pre-commit": "lint-staged"
   },
   "homepage": "https://github.com/smartcontracts/chugsplash/tree/develop/packages/contracts#readme",

--- a/packages/core/src/languages/solidity/predeploys.ts
+++ b/packages/core/src/languages/solidity/predeploys.ts
@@ -48,7 +48,6 @@ import {
   managerConstructorValues,
   registryConstructorValues,
   CHUGSPLASH_MANAGER_V1_ADDRESS,
-  CURRENT_CHUGSPLASH_MANAGER_VERSION,
 } from '../../constants'
 
 export const initializeChugSplash = async (
@@ -249,11 +248,8 @@ export const initializeChugSplash = async (
     ).wait()
 
     await (
-      await ChugSplashRegistry.connect(multisig).setVersion(
+      await ChugSplashRegistry.connect(multisig).addVersion(
         ChugSplashManager.address,
-        CURRENT_CHUGSPLASH_MANAGER_VERSION.major,
-        CURRENT_CHUGSPLASH_MANAGER_VERSION.minor,
-        CURRENT_CHUGSPLASH_MANAGER_VERSION.patch,
         await getGasPriceOverrides(provider)
       )
     ).wait()

--- a/packages/plugins/contracts/Stateless.sol
+++ b/packages/plugins/contracts/Stateless.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.9;
 
 import { Storage } from "./Storage.sol";
+import { Version } from "@chugsplash/contracts/contracts/Semver.sol";
 
 contract Stateless {
     uint immutable public immutableUint;
@@ -10,6 +11,10 @@ contract Stateless {
     constructor(uint _immutableUint, Storage _immutableContractReference) {
         immutableUint = _immutableUint;
         immutableContractReference = _immutableContractReference;
+    }
+
+    function version() external pure returns (Version memory) {
+        return Version(2, 0, 0);
     }
 
     function hello() pure external returns (string memory) {

--- a/packages/plugins/test/ManagerUpgrade.spec.ts
+++ b/packages/plugins/test/ManagerUpgrade.spec.ts
@@ -1,7 +1,7 @@
 import '@nomiclabs/hardhat-ethers'
 
 import hre, { chugsplash } from 'hardhat'
-import { Contract } from 'ethers'
+import { BigNumber, Contract } from 'ethers'
 import {
   getChugSplashManagerAddress,
   getChugSplashRegistry,
@@ -26,7 +26,7 @@ describe('Manager Upgrade', () => {
       '0x10000000000000000000',
     ])
     const registry = await getChugSplashRegistry(signer)
-    await registry.setVersion(Stateless.address, 2, 0, 0)
+    await registry.addVersion(Stateless.address)
   })
 
   it('does upgrade chugsplash manager', async () => {
@@ -50,6 +50,7 @@ describe('Manager Upgrade', () => {
       signer
     )
 
-    expect(await StatelessManager.hello()).to.equal('Hello, world!')
+    const version = await StatelessManager.version()
+    expect(version.major).to.deep.equal(BigNumber.from(2))
   })
 })


### PR DESCRIPTION
Previously, it was possible for the major/minor/patch inputs to the ChugSplashRegistry's `setVersion` function to differ from the ChugSplashManager's actual Semver version. This isn't likely to happen, but it'd be nice if this was prevented on-chain.

This PR changes the registry's `addVersion` function to read the semver versions from the ChugSplashManager.To do this, I created our own `Semver` contract, which is the same as Optimism's except our `Semver.version()` function returns a `Version` struct instead of a string. This `Version` struct is used in the registry's `addVersion` function to determine the keys of the `versions` mapping.

This PR also adds a `VersionAdded` event to the `addVersion` function.