### PR TITLE
maint(core): confirm upgrade after checking for validation errors

### DIFF
--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -2157,6 +2157,13 @@ export const parseAndValidateChugSplashConfig = async (
     cre
   )
 
+  // Exit if validation errors are detected
+  // We also allow the user to disable this behavior by setting `exitOnFailure` to false.
+  // This is useful for testing.
+  if (validationErrors && exitOnFailure) {
+    process.exit(1)
+  }
+
   // Confirm upgrade with user
   if (!cre.autoConfirm && upgrade) {
     const userConfirmed = await yesno({
@@ -2165,13 +2172,6 @@ export const parseAndValidateChugSplashConfig = async (
     if (!userConfirmed) {
       throw new Error(`User denied upgrade.`)
     }
-  }
-
-  // Exit if validation errors are detected
-  // We also allow the user to disable this behavior by setting `exitOnFailure` to false.
-  // This is useful for testing.
-  if (validationErrors && exitOnFailure) {
-    process.exit(1)
   }
 
   return parsedConfig

--- a/packages/demo/chugsplash/hello-chugsplash.ts
+++ b/packages/demo/chugsplash/hello-chugsplash.ts
@@ -14,7 +14,7 @@ const config: UserChugSplashConfig = {
         number: 1,
         stored: true,
         storageName: 'First',
-        otherStorage: '0x1111111111111111111111111111111111111111',
+        otherStorage: '  {{MyFirstContrfact}}  ',
       },
     },
   },


### PR DESCRIPTION
We previously prompted the user to confirm an upgrade even if a validation error was about to be thrown. This PR fixes that issue by putting the confirmation logic after we check for any validation errors.