### PR TITLE
maint(ct): remove non-proxied contracts from target bundles

### DIFF
--- a/packages/core/src/actions/bundle.ts
+++ b/packages/core/src/actions/bundle.ts
@@ -415,7 +415,8 @@ export const makeActionBundleFromConfig = async (
 }
 
 /**
- * Generates a ChugSplash target bundle from a config file.
+ * Generates a ChugSplash target bundle from a config file. Note that non-proxied contract types are
+ * not included in the target bundle.
  *
  * @param config Config file to convert into a bundle.
  * @param env Environment variables to inject into the config file.
@@ -433,18 +434,21 @@ export const makeTargetBundleFromConfig = (
   for (const [referenceName, contractConfig] of Object.entries(
     parsedConfig.contracts
   )) {
-    targets.push({
-      projectName,
-      referenceName,
-      contractKindHash: contractKindHashes[contractConfig.kind],
-      proxy: contractConfig.proxy,
-      implementation: getContractAddress(
-        managerAddress,
+    // Only add targets for proxies.
+    if (contractConfig.kind !== 'no-proxy') {
+      targets.push({
+        projectName,
         referenceName,
-        contractConfig.constructorArgs,
-        artifacts[referenceName]
-      ),
-    })
+        contractKindHash: contractKindHashes[contractConfig.kind],
+        proxy: contractConfig.proxy,
+        implementation: getContractAddress(
+          managerAddress,
+          referenceName,
+          contractConfig.constructorArgs,
+          artifacts[referenceName]
+        ),
+      })
+    }
   }
 
   // Generate a bundle from the list of actions.

--- a/packages/demo/chugsplash/hello-chugsplash.ts
+++ b/packages/demo/chugsplash/hello-chugsplash.ts
@@ -14,7 +14,7 @@ const config: UserChugSplashConfig = {
         number: 1,
         stored: true,
         storageName: 'First',
-        otherStorage: '  {{MyFirstContrfact}}  ',
+        otherStorage: '0x1111111111111111111111111111111111111111',
       },
     },
   },


### PR DESCRIPTION
Previously, non-proxied contracts were included in the target bundle, which is the bundle used in the `initiateExecution` and `completeExecution` functions to initialize/finalize each proxy. It's pointless to include non-proxied contracts in these functions, and doing so would actually complicate these functions because non-proxied contracts don't have adapters.