### PR TITLE
fix(ct): move `adapter.initiateExecution` into the proper ChugSplashManager function

### DIFF
--- a/.changeset/heavy-parrots-swim.md
+++ b/.changeset/heavy-parrots-swim.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/contracts': patch
+---
+
+Move `adapter.initiateExecution` function into the corresponding function in the ChugSplashManager


### PR DESCRIPTION
Previously, `adapter.initiateExecution` was inside `ChugSplashManager.executeActions` instead of `ChugSplashManager.initiateBundleExecution`.