### PR TITLE
fix(ct): add reentrancy guards to the bundle initiation and completion functions

### DIFF
--- a/.changeset/healthy-dodos-help.md
+++ b/.changeset/healthy-dodos-help.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/contracts': patch
+---
+
+Add reentrancy guards to the bundle initiation and completion functions

--- a/packages/contracts/contracts/ChugSplashManager.sol
+++ b/packages/contracts/contracts/ChugSplashManager.sol
@@ -521,7 +521,7 @@ contract ChugSplashManager is OwnableUpgradeable, ReentrancyGuardUpgradeable, Se
     function initiateBundleExecution(
         ChugSplashTarget[] memory _targets,
         bytes32[][] memory _proofs
-    ) public {
+    ) public nonReentrant {
         uint256 initialGasLeft = gasleft();
 
         ChugSplashBundleState storage bundle = _bundles[activeBundleId];
@@ -720,7 +720,7 @@ contract ChugSplashManager is OwnableUpgradeable, ReentrancyGuardUpgradeable, Se
     function completeBundleExecution(
         ChugSplashTarget[] memory _targets,
         bytes32[][] memory _proofs
-    ) public {
+    ) public nonReentrant {
         uint256 initialGasLeft = gasleft();
 
         ChugSplashBundleState storage bundle = _bundles[activeBundleId];


### PR DESCRIPTION
This is a cautionary measure since both functions have an external call to the `adapter`.