### PR TITLE
maint(ct): move gas price calculation into modular contract

### DIFF
--- a/packages/contracts/contracts/DefaultGasPriceCalculator.sol
+++ b/packages/contracts/contracts/DefaultGasPriceCalculator.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import { IGasPriceCalculator } from "./interfaces/IGasPriceCalculator.sol";
+
+/**
+ * @title DefaultGasPriceCalculator
+ */
+contract DefaultGasPriceCalculator is IGasPriceCalculator {
+    function getGasPrice() external view returns (uint256) {
+        return tx.gasprice;
+    }
+}

--- a/packages/contracts/contracts/interfaces/IGasPriceCalculator.sol
+++ b/packages/contracts/contracts/interfaces/IGasPriceCalculator.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+/**
+ * @title IGasPriceCalculator
+ */
+interface IGasPriceCalculator {
+    function getGasPrice() external view returns (uint256);
+}

--- a/packages/contracts/src/constants.ts
+++ b/packages/contracts/src/constants.ts
@@ -7,6 +7,7 @@ import {
   OZTransparentAdapterArtifact,
   OZUUPSOwnableAdapterArtifact,
   OZUUPSAccessControlAdapterArtifact,
+  DefaultGasPriceCalculatorArtifact,
 } from './ifaces'
 
 export const OWNER_MULTISIG_ADDRESS =
@@ -41,6 +42,16 @@ export const OWNER_BOND_AMOUNT = ethers.utils.parseEther('0.001')
 export const EXECUTION_LOCK_TIME = 15 * 60
 export const EXECUTOR_PAYMENT_PERCENTAGE = 20
 export const PROTOCOL_PAYMENT_PERCENTAGE = 20
+
+export const DEFAULT_GAS_PRICE_CALCULATOR_ADDRESS =
+  ethers.utils.getCreate2Address(
+    DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
+    ethers.constants.HashZero,
+    ethers.utils.solidityKeccak256(
+      ['bytes'],
+      [DefaultGasPriceCalculatorArtifact.bytecode]
+    )
+  )
 
 export const DEFAULT_UPDATER_ADDRESS = ethers.utils.getCreate2Address(
   DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,

--- a/packages/contracts/src/ifaces.ts
+++ b/packages/contracts/src/ifaces.ts
@@ -13,6 +13,7 @@ export const DefaultAdapterArtifact = require('../artifacts/contracts/adapters/D
 export const OZUUPSOwnableAdapterArtifact = require('../artifacts/contracts/adapters/OZUUPSOwnableAdapter.sol/OZUUPSOwnableAdapter.json')
 export const OZUUPSAccessControlAdapterArtifact = require('../artifacts/contracts/adapters/OZUUPSAccessControlAdapter.sol/OZUUPSAccessControlAdapter.json')
 export const OZTransparentAdapterArtifact = require('../artifacts/contracts/adapters/OZTransparentAdapter.sol/OZTransparentAdapter.json')
+export const DefaultGasPriceCalculatorArtifact = require('../artifacts/contracts/DefaultGasPriceCalculator.sol/DefaultGasPriceCalculator.json')
 
 const directoryPath = path.join(__dirname, '../artifacts/build-info')
 const fileNames = fs.readdirSync(directoryPath)
@@ -36,3 +37,5 @@ export const OZUUPSOwnableAdapterABI = OZUUPSOwnableAdapterArtifact.abi
 export const OZUUPSAccessControlAdapterABI =
   OZUUPSAccessControlAdapterArtifact.abi
 export const OZTransparentAdapterABI = OZTransparentAdapterArtifact.abi
+export const DefaultGasPriceCalculatorABI =
+  DefaultGasPriceCalculatorArtifact.abi

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -18,6 +18,7 @@ import {
   ChugSplashRegistryABI,
   ManagedServiceArtifact,
   ChugSplashManagerABI,
+  DEFAULT_GAS_PRICE_CALCULATOR_ADDRESS,
 } from '@chugsplash/contracts'
 import { utils, constants } from 'ethers'
 import { CustomChain } from '@nomiclabs/hardhat-etherscan/dist/src/types'
@@ -95,6 +96,7 @@ export const CURRENT_CHUGSPLASH_MANAGER_VERSION = {
 
 export const managerConstructorValues = [
   CHUGSPLASH_REGISTRY_ADDRESS,
+  DEFAULT_GAS_PRICE_CALCULATOR_ADDRESS,
   MANAGED_SERVICE_ADDRESS,
   EXECUTION_LOCK_TIME,
   OWNER_BOND_AMOUNT.toString(),

--- a/packages/core/src/languages/solidity/predeploys.ts
+++ b/packages/core/src/languages/solidity/predeploys.ts
@@ -32,6 +32,9 @@ import {
   ChugSplashManagerABI,
   ChugSplashManagerArtifact,
   DEFAULT_ADAPTER_ADDRESS,
+  DefaultGasPriceCalculatorABI,
+  DefaultGasPriceCalculatorArtifact,
+  DEFAULT_GAS_PRICE_CALCULATOR_ADDRESS,
 } from '@chugsplash/contracts'
 import { Logger } from '@eth-optimism/common-ts'
 
@@ -55,6 +58,25 @@ export const initializeChugSplash = async (
   deployer: ethers.Signer,
   logger?: Logger
 ): Promise<void> => {
+  logger?.info('[ChugSplash]: deploying DefaultGasPriceCalculator...')
+
+  const DefaultGasPriceCalculator = await doDeterministicDeploy(provider, {
+    signer: deployer,
+    contract: {
+      abi: DefaultGasPriceCalculatorABI,
+      bytecode: DefaultGasPriceCalculatorArtifact.bytecode,
+    },
+    args: [],
+    salt: ethers.constants.HashZero,
+  })
+
+  assert(
+    DEFAULT_GAS_PRICE_CALCULATOR_ADDRESS === DefaultGasPriceCalculator.address,
+    'DefaultGasPriceCalculator has incorrect address'
+  )
+
+  logger?.info('[ChugSplash]: deployed DefaultGasPriceCalculator')
+
   logger?.info('[ChugSplash]: deploying ManagedService...')
 
   const ManagedService = await doDeterministicDeploy(provider, {

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -1166,14 +1166,14 @@ export const chugsplashListProposersAbstractTask = async (
 
   // Fetch all previous proposers
   const addProposerEvents = await ChugSplashManager.queryFilter(
-    ChugSplashManager.filters.ProposerAdded()
+    ChugSplashManager.filters.ProposerSet(null, true)
   )
 
   // Verify if each previous proposer is still a proposer before adding it to the list
   for (const proposerEvent of addProposerEvents) {
     if (proposerEvent.args === undefined) {
       throw new Error(
-        `No args found for ProposerAdded event. Should never happen.`
+        `No args found for ProposerSet event. Should never happen.`
       )
     }
 
@@ -1254,8 +1254,9 @@ export const chugsplashAddProposersAbstractTask = async (
     }
 
     await (
-      await ChugSplashManager.addProposer(
+      await ChugSplashManager.setProposer(
         newProposer,
+        true,
         await getGasPriceOverrides(provider)
       )
     ).wait()

--- a/packages/plugins/test/foundry/ChugSplash.t.sol
+++ b/packages/plugins/test/foundry/ChugSplash.t.sol
@@ -13,6 +13,7 @@ import { ChugSplashManagerProxy } from "@chugsplash/contracts/contracts/ChugSpla
 import { IChugSplashManager } from "@chugsplash/contracts/contracts/interfaces/IChugSplashManager.sol";
 import { IProxyAdapter } from "@chugsplash/contracts/contracts/interfaces/IProxyAdapter.sol";
 import { IProxyUpdater } from "@chugsplash/contracts/contracts/interfaces/IProxyUpdater.sol";
+import { IGasPriceCalculator } from "@chugsplash/contracts/contracts/interfaces/IGasPriceCalculator.sol";
 
 /* ChugSplash Foundry Library Tests
  *


### PR DESCRIPTION
Many chains calculate gas in different ways, so this PR moves the gas price calculation into a separate contract from the ChugSplashManager.