### PR TITLE
feat(core): Allow function types in contracts

### DIFF
--- a/.changeset/cool-donkeys-pull.md
+++ b/.changeset/cool-donkeys-pull.md
@@ -1,0 +1,6 @@
+---
+'@chugsplash/plugins': patch
+'@chugsplash/core': patch
+---
+
+Allow function types in contracts

--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -944,6 +944,19 @@ export const parseGap = (
   )
 }
 
+/**
+ * Handles parsing and validating functions, in practice this function does nothing because
+ * functions should not be defined in the ChugSplash config.
+ *
+ * @param props standard VariableHandler props. See ./iterator.ts for more information.
+ * @returns undefined
+ */
+export const parseFunction: VariableHandler<string, string> = (
+  props: VariableHandlerProps<string, string>
+): string => {
+  return props.variable
+}
+
 export const handleParseOnlyKeywords = (
   storageObj: SolidityStorageObj,
   variableType: SolidityStorageType,
@@ -996,6 +1009,7 @@ export const parseAndValidateVariable = (
     mapping: parseMapping,
     dynamic_array: parseDynamicArray,
     preserve: parsePreserve,
+    function: parseFunction,
   }
 
   // Handle any keywords that are only used for parsing, not encoding.
@@ -1059,8 +1073,18 @@ const parseContractVariables = (
 
   for (const storageObj of Object.values(extendedLayout.storage)) {
     const configVarValue = userConfigVariables[storageObj.configVarName]
-    if (configVarValue === undefined) {
+    if (
+      configVarValue === undefined &&
+      !storageObj.type.startsWith('t_function')
+    ) {
       missingVariables.push(storageObj.configVarName)
+    } else if (
+      configVarValue !== undefined &&
+      storageObj.type.startsWith('t_function')
+    ) {
+      inputErrors.push(
+        `Detected value for ${storageObj.configVarName} which is a function. Function variables should be ommitted from your ChugSplash config.`
+      )
     }
 
     try {

--- a/packages/core/src/languages/solidity/iterator.ts
+++ b/packages/core/src/languages/solidity/iterator.ts
@@ -37,6 +37,7 @@ export type VariableHandlers<Output> = {
   mapping: VariableHandler<UserConfigVariable, Output>
   dynamic_array: VariableHandler<UserConfigVariable, Output>
   preserve: VariableHandler<UserConfigVariable, Output>
+  function: VariableHandler<UserConfigVariable, Output>
 }
 
 export const isKeyword = (
@@ -348,6 +349,17 @@ export const recursiveLayoutIterator = <Output>(
       })
     } else if (variableType.label.startsWith('struct')) {
       return typeHandlers.inplace.struct({
+        variable,
+        storageObj,
+        storageTypes,
+        nestedSlotOffset,
+        slotKey,
+        variableType,
+        typeHandlers,
+        dereferencer,
+      })
+    } else if (storageObj.type.startsWith('t_function')) {
+      return typeHandlers.function({
         variable,
         storageObj,
         storageTypes,

--- a/packages/plugins/chugsplash/VariableValidation.config.ts
+++ b/packages/plugins/chugsplash/VariableValidation.config.ts
@@ -56,6 +56,7 @@ const config: UserChugSplashConfig = {
         // variables that are not in the contract
         extraVar: 214830928,
         anotherExtraVar: [],
+        functionType: {},
       },
     },
     Stateless: {

--- a/packages/plugins/contracts/Storage.sol
+++ b/packages/plugins/contracts/Storage.sol
@@ -58,8 +58,10 @@ contract Storage {
         immutableEnum = _immutableEnum;
     }
 
-    int public minInt256;
+    function(uint256) pure internal returns (uint256) internalFunc;
     int8 public minInt8;
+    function(uint256) pure external returns (uint256) externalFunc;
+    int public minInt256;
     int public bigNumberInt256;
     int8 public bigNumberInt8;
     uint public bigNumberUint256;

--- a/packages/plugins/contracts/VariableValidation.sol
+++ b/packages/plugins/contracts/VariableValidation.sol
@@ -30,4 +30,7 @@ contract VariableValidation {
     // Variables that are not set in the config
     uint public notSetUint;
     string public notSetString;
+
+    // Variables that should not be set in the config (but are)
+    function(uint256) pure internal returns (uint256) functionType;
 }

--- a/packages/plugins/test/Validation.spec.ts
+++ b/packages/plugins/test/Validation.spec.ts
@@ -362,4 +362,10 @@ describe('Validate', () => {
       `Invalid contract reference: {{ Stateless }}. Contract references to no-proxy contracts are not allowed in other no-proxy contracts.`
     )
   })
+
+  it('did catch invalid definition of function type', async () => {
+    expect(validationOutput).to.have.string(
+      `Detected value for functionType which is a function. Function variables should be ommitted from your ChugSplash config.`
+    )
+  })
 })


### PR DESCRIPTION
## Purpose
Allows the user to define function types in their contracts:
- Function values cannot be defined in the config, if they are then a validation error is thrown
- During encoding, we explicitly zero out the slot key of any function types