### PR TITLE
feat(pg): Only initialize ChugSplash on local networks

### DIFF
--- a/.changeset/empty-weeks-float.md
+++ b/.changeset/empty-weeks-float.md
@@ -1,0 +1,7 @@
+---
+'@chugsplash/executor': patch
+'@chugsplash/plugins': patch
+'@chugsplash/core': patch
+---
+
+Only initialize ChugSplash on local networks

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -12,7 +12,6 @@ import { ethers } from 'ethers'
 import { ChugSplashRegistryABI } from '@chugsplash/contracts'
 import {
   CHUGSPLASH_REGISTRY_ADDRESS,
-  initializeChugSplash,
   ExecutorOptions,
   ExecutorMetrics,
   ExecutorState,
@@ -20,6 +19,7 @@ import {
   ExecutorKey,
   isSupportedNetworkOnEtherscan,
   verifyChugSplash,
+  ensureChugSplashInitialized,
 } from '@chugsplash/core'
 import { getChainId } from '@eth-optimism/core-utils'
 import { GraphQLClient } from 'graphql-request'
@@ -141,7 +141,7 @@ export class ChugSplashExecutor extends BaseServiceV2<
     }
 
     // Deploy the ChugSplash contracts.
-    await initializeChugSplash(this.state.provider, wallet, this.logger)
+    await ensureChugSplashInitialized(this.state.provider, wallet)
 
     this.logger.info('[ChugSplash]: finished setting up chugsplash')
 

--- a/packages/plugins/src/foundry/index.ts
+++ b/packages/plugins/src/foundry/index.ts
@@ -15,7 +15,6 @@ import {
   chugsplashExportProxyAbstractTask,
   chugsplashImportProxyAbstractTask,
   getEIP1967ProxyAdminAddress,
-  initializeChugSplash,
   readValidatedChugSplashConfig,
   getDefaultProxyAddress,
   readUnvalidatedChugSplashConfig,
@@ -24,6 +23,7 @@ import {
   getChugSplashManagerAddress,
   isLiveNetwork,
   assertValidConstructorArgs,
+  ensureChugSplashInitialized,
 } from '@chugsplash/core'
 import { BigNumber, ethers } from 'ethers'
 
@@ -761,7 +761,7 @@ const command = args[0]
 
       const provider = new ethers.providers.JsonRpcProvider(rpcUrl, network)
       const wallet = new ethers.Wallet(privateKey, provider)
-      await initializeChugSplash(provider, wallet)
+      await ensureChugSplashInitialized(provider, wallet)
       break
     }
   }

--- a/packages/plugins/src/hardhat/tasks.ts
+++ b/packages/plugins/src/hardhat/tasks.ts
@@ -13,7 +13,6 @@ import {
   ParsedChugSplashConfig,
   getChugSplashRegistry,
   chugsplashFetchSubtask,
-  initializeChugSplash,
   chugsplashClaimAbstractTask,
   chugsplashCommitAbstractSubtask,
   bundleLocal,
@@ -37,6 +36,7 @@ import {
   readValidatedChugSplashConfig,
   readUnvalidatedChugSplashConfig,
   isLiveNetwork,
+  ensureChugSplashInitialized,
 } from '@chugsplash/core'
 import { ChugSplashManagerABI } from '@chugsplash/contracts'
 import ora from 'ora'
@@ -144,7 +144,7 @@ export const chugsplashDeployTask = async (
   const provider = hre.ethers.provider
   const signer = hre.ethers.provider.getSigner()
   const signerAddress = await signer.getAddress()
-  await initializeChugSplash(hre.ethers.provider, signer)
+  await ensureChugSplashInitialized(provider, signer)
 
   const canonicalConfigPath = hre.config.paths.canonicalConfigs
   const deploymentFolder = hre.config.paths.deployments
@@ -214,7 +214,7 @@ export const chugsplashClaimTask = async (
 
   const provider = hre.ethers.provider
   const signer = hre.ethers.provider.getSigner()
-  await initializeChugSplash(hre.ethers.provider, signer)
+  await ensureChugSplashInitialized(provider, signer)
 
   const userConfig = await readUnvalidatedChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
@@ -286,7 +286,7 @@ export const chugsplashProposeTask = async (
 
   const provider = hre.ethers.provider
   const signer = hre.ethers.provider.getSigner()
-  await initializeChugSplash(hre.ethers.provider, signer)
+  await ensureChugSplashInitialized(provider, signer)
 
   const artifactPaths = await getArtifactPaths(
     hre,
@@ -356,7 +356,7 @@ export const chugsplashApproveTask = async (
   const provider = hre.ethers.provider
   const signer = hre.ethers.provider.getSigner()
 
-  await initializeChugSplash(hre.ethers.provider, signer)
+  await ensureChugSplashInitialized(provider, signer)
 
   const deploymentFolder = hre.config.paths.deployments
   const artifactPaths = await getArtifactPaths(
@@ -403,7 +403,7 @@ subtask(TASK_CHUGSPLASH_LIST_ALL_PROJECTS)
   .setAction(async (_, hre) => {
     const signer = hre.ethers.provider.getSigner()
 
-    await initializeChugSplash(hre.ethers.provider, signer)
+    await ensureChugSplashInitialized(hre.ethers.provider, signer)
 
     const ChugSplashRegistry = getChugSplashRegistry(
       hre.ethers.provider.getSigner()
@@ -495,7 +495,7 @@ subtask(TASK_CHUGSPLASH_LIST_BUNDLES)
     ) => {
       const signer = hre.ethers.provider.getSigner()
 
-      await initializeChugSplash(hre.ethers.provider, signer)
+      await ensureChugSplashInitialized(hre.ethers.provider, signer)
 
       const ChugSplashRegistry = getChugSplashRegistry(signer)
 
@@ -626,7 +626,7 @@ export const monitorTask = async (
   const provider = hre.ethers.provider
   const signer = hre.ethers.provider.getSigner()
 
-  await initializeChugSplash(hre.ethers.provider, signer)
+  await ensureChugSplashInitialized(provider, signer)
 
   const deploymentFolder = hre.config.paths.deployments
   const userConfig = await readUnvalidatedChugSplashConfig(configPath)
@@ -691,7 +691,7 @@ export const chugsplashFundTask = async (
   const provider = hre.ethers.provider
   const signer = hre.ethers.provider.getSigner()
 
-  await initializeChugSplash(hre.ethers.provider, signer)
+  await ensureChugSplashInitialized(provider, signer)
 
   const userConfig = await readUnvalidatedChugSplashConfig(configPath)
   const artifactPaths = await getArtifactPaths(
@@ -760,7 +760,7 @@ task(TASK_NODE)
 
         const signer = hre.ethers.provider.getSigner()
 
-        await initializeChugSplash(hre.ethers.provider, signer)
+        await ensureChugSplashInitialized(hre.ethers.provider, signer)
 
         spinner.succeed('ChugSplash has been initialized.')
 
@@ -832,7 +832,7 @@ task(TASK_TEST)
             throw new Error('Snapshot failed to be reverted.')
           }
         } catch {
-          await initializeChugSplash(hre.ethers.provider, signer)
+          await ensureChugSplashInitialized(hre.ethers.provider, signer)
           if (!noCompile) {
             await hre.run(TASK_COMPILE, {
               quiet: true,
@@ -881,7 +881,7 @@ task(TASK_RUN)
       if (deployAll) {
         const signer = hre.ethers.provider.getSigner()
 
-        await initializeChugSplash(hre.ethers.provider, signer)
+        await ensureChugSplashInitialized(hre.ethers.provider, signer)
         if (!noCompile) {
           await hre.run(TASK_COMPILE, {
             quiet: true,


### PR DESCRIPTION
## Purpose
Prevents users from accidentally deploying ChugSplash on unsupported networks. ChugSplash will only be deployed automatically on local networks. If a user attempts to run ChugSplash on a live network where the contracts have not been deployed, we output an error stating that the network is not currently supported. 

Also fixes a bug where attempting to deploy ChugSplash against a network where it has already been deployed fails due to the `addVersion` step.