### PR TITLE
fix(core): Improve execution gas cost estimation

### DIFF
--- a/packages/contracts/src/ifaces.ts
+++ b/packages/contracts/src/ifaces.ts
@@ -14,6 +14,7 @@ export const OZUUPSOwnableAdapterArtifact = require('../artifacts/contracts/adap
 export const OZUUPSAccessControlAdapterArtifact = require('../artifacts/contracts/adapters/OZUUPSAccessControlAdapter.sol/OZUUPSAccessControlAdapter.json')
 export const OZTransparentAdapterArtifact = require('../artifacts/contracts/adapters/OZTransparentAdapter.sol/OZTransparentAdapter.json')
 export const DefaultGasPriceCalculatorArtifact = require('../artifacts/contracts/DefaultGasPriceCalculator.sol/DefaultGasPriceCalculator.json')
+export const DefaultProxyArtifact = require('../node_modules/@eth-optimism/contracts-bedrock/artifacts/contracts/universal/Proxy.sol/Proxy.json')
 
 const directoryPath = path.join(__dirname, '../artifacts/build-info')
 const fileNames = fs.readdirSync(directoryPath)

--- a/packages/core/src/actions/artifacts.ts
+++ b/packages/core/src/actions/artifacts.ts
@@ -130,7 +130,6 @@ export const writeDeploymentArtifacts = async (
       )
       const { constructorArgValues } = getConstructorArgs(
         parsedConfig.contracts[referenceName].constructorArgs,
-        referenceName,
         abi
       )
       const { metadata, storageLayout } =

--- a/packages/core/src/actions/bundle.ts
+++ b/packages/core/src/actions/bundle.ts
@@ -303,7 +303,6 @@ export const bundleLocal = async (
     const creationCodeWithConstructorArgs = getCreationCodeWithConstructorArgs(
       bytecode,
       contractConfig.constructorArgs,
-      referenceName,
       abi
     )
     artifacts[referenceName] = {

--- a/packages/core/src/etherscan.ts
+++ b/packages/core/src/etherscan.ts
@@ -90,7 +90,6 @@ export const verifyChugSplashConfig = async (
     const { abi, contractName, sourceName } = artifact
     const { constructorArgValues } = getConstructorArgs(
       canonicalConfig.contracts[referenceName].constructorArgs,
-      referenceName,
       abi
     )
     const implementationAddress = getContractAddress(

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -92,7 +92,6 @@ export const monitorExecution = async (
       bundleState.actionsExecuted.toNumber(),
       claimer,
       organizationID,
-      projectName,
       false
     )
     if (amountToDeposit.gt(0)) {

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -211,7 +211,6 @@ export const chugsplashProposeAbstractTask = async (
       0,
       parsedConfig.options.claimer,
       parsedConfig.options.organizationID,
-      parsedConfig.options.projectName,
       true
     )
 
@@ -569,7 +568,6 @@ export const chugsplashFundAbstractTask = async (
         0,
         parsedConfig.options.claimer,
         parsedConfig.options.organizationID,
-        parsedConfig.options.projectName,
         true
       )
     : amount

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -830,7 +830,6 @@ export const getContractAddress = (
   const creationCodeWithConstructorArgs = getCreationCodeWithConstructorArgs(
     bytecode,
     constructorArgs ?? {},
-    referenceName,
     abi
   )
 
@@ -843,7 +842,6 @@ export const getContractAddress = (
 
 export const getConstructorArgs = (
   constructorArgs: UserConfigVariables,
-  referenceName: string,
   abi: Array<Fragment>
 ): {
   constructorArgTypes: Array<string>
@@ -872,12 +870,10 @@ export const getConstructorArgs = (
 export const getCreationCodeWithConstructorArgs = (
   bytecode: string,
   constructorArgs: UserConfigVariables,
-  referenceName: string,
   abi: any
 ): string => {
   const { constructorArgTypes, constructorArgValues } = getConstructorArgs(
     constructorArgs,
-    referenceName,
     abi
   )
 
@@ -1238,7 +1234,6 @@ export const getCanonicalConfigArtifacts = async (
           getCreationCodeWithConstructorArgs(
             add0x(contractOutput.evm.bytecode.object),
             contractConfig.constructorArgs,
-            referenceName,
             contractOutput.abi
           )
 

--- a/packages/executor/src/utils/execute.ts
+++ b/packages/executor/src/utils/execute.ts
@@ -232,8 +232,7 @@ export const handleExecution = async (data: ExecutorMessage) => {
       bundles,
       bundleState.actionsExecuted.toNumber(),
       claimer,
-      organizationID,
-      projectName
+      organizationID
     )
   ) {
     logger.info(`[ChugSplash]: ${projectName} has sufficient funds`)


### PR DESCRIPTION
## Purpose
Improves our off-chain gas cost estimation logic
- Only includes the cost of deploying a proxy if a proxy has not yet been deployed
- Uses the actual cost of deploying the default proxy instead of a fixed value
- Does not include the cost of deploying any implementation contracts that have already been deployed
- Reduces the estimated cost of each set storage action to 45k gas
- Adds a fixed buffer of 400k to account for the initiate and complete function calls

## Note
While this estimation logic is substantially better than what we had before, it is not perfect. We could improve it by adding more complex logic to estimate the cost of the initiate and complete function calls since those have a variable cost in practice. That being said, I think this is sufficient for now given that we are using a federated executor model and we expect anyone using remote execution to be a user of the managed service. We should come back to this if we find that it is not accurate enough for our immediate use case, or when we want to move to a trustless network of executors. 

## Testing
Unfortunately, this is somewhat difficult to test since we're no longer using this logic in the deploy task. We could do automated testing but that doesn't seem worth it to me in this case. So instead, I tested this by temporarily modifying the deploy task to call the `estimateExecutionCost` function, printing the result, and comparing that to the actual cost which was calculated based on the signers' balance before and after the deployment. I then deployed a bunch of different configs to ensure it worked well in a variety of situations. 