### PR TITLE
fix(ct): allow executor to specify amount of debt to withdraw

### DIFF
--- a/.changeset/nasty-clouds-wonder.md
+++ b/.changeset/nasty-clouds-wonder.md
@@ -1,0 +1,6 @@
+---
+'@chugsplash/contracts': patch
+'@chugsplash/core': patch
+---
+
+Allow executor to withdraw specified amount of debt

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -399,10 +399,17 @@ export const claimExecutorPayment = async (
   executor: Wallet,
   ChugSplashManager: Contract
 ) => {
-  const executorDebt = await ChugSplashManager.executorDebt(executor.address)
-  if (executorDebt.gt(0)) {
+  // The amount to withdraw is the minimum of the executor's debt and the ChugSplashManager's
+  // balance.
+  const withdrawAmount = Math.min(
+    await ChugSplashManager.executorDebt(executor.address),
+    await ChugSplashManager.getBalance()
+  )
+
+  if (withdrawAmount > 0) {
     await (
       await ChugSplashManager.claimExecutorPayment(
+        withdrawAmount,
         await getGasPriceOverrides(executor.provider)
       )
     ).wait()


### PR DESCRIPTION
Previously, it was possible for a low balance of ETH in the ChugSplashManager to prevent an executor from withdrawing any of their debt. This PR fixes this issue by allowing the executor to specify an amount to withdraw (as long as it's below the debt owed to them).

This PR also shortens some error strings in the ChugSplashManager to get it under the contract size limit.