### PR TITLE
fix(ct): use general create2 contract

### DIFF
--- a/.changeset/soft-lies-pay.md
+++ b/.changeset/soft-lies-pay.md
@@ -1,0 +1,6 @@
+---
+'@chugsplash/contracts': patch
+'@chugsplash/core': patch
+---
+
+Use general Create2 contract

--- a/packages/contracts/contracts/DefaultCreate2.sol
+++ b/packages/contracts/contracts/DefaultCreate2.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
+import { ICreate2 } from "./interfaces/ICreate2.sol";
+
+/**
+ * @title DefaultCreate2
+ */
+contract DefaultCreate2 is ICreate2 {
+    function computeAddress(
+        bytes32 _salt,
+        bytes32 _bytecodeHash,
+        address _deployer
+    ) external pure returns (address) {
+        return Create2.computeAddress(_salt, _bytecodeHash, _deployer);
+    }
+}

--- a/packages/contracts/contracts/interfaces/ICreate2.sol
+++ b/packages/contracts/contracts/interfaces/ICreate2.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+interface ICreate2 {
+    function computeAddress(
+        bytes32 _salt,
+        bytes32 _bytecodeHash,
+        address _deployer
+    ) external pure returns (address);
+}

--- a/packages/contracts/src/constants.ts
+++ b/packages/contracts/src/constants.ts
@@ -8,6 +8,7 @@ import {
   OZUUPSOwnableAdapterArtifact,
   OZUUPSAccessControlAdapterArtifact,
   DefaultGasPriceCalculatorArtifact,
+  DefaultCreate2Artifact,
 } from './ifaces'
 
 export const OWNER_MULTISIG_ADDRESS =
@@ -42,6 +43,12 @@ export const OWNER_BOND_AMOUNT = ethers.utils.parseEther('0.001')
 export const EXECUTION_LOCK_TIME = 15 * 60
 export const EXECUTOR_PAYMENT_PERCENTAGE = 20
 export const PROTOCOL_PAYMENT_PERCENTAGE = 20
+
+export const DEFAULT_CREATE2_ADDRESS = ethers.utils.getCreate2Address(
+  DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
+  ethers.constants.HashZero,
+  ethers.utils.solidityKeccak256(['bytes'], [DefaultCreate2Artifact.bytecode])
+)
 
 export const DEFAULT_GAS_PRICE_CALCULATOR_ADDRESS =
   ethers.utils.getCreate2Address(

--- a/packages/contracts/src/ifaces.ts
+++ b/packages/contracts/src/ifaces.ts
@@ -14,6 +14,7 @@ export const OZUUPSOwnableAdapterArtifact = require('../artifacts/contracts/adap
 export const OZUUPSAccessControlAdapterArtifact = require('../artifacts/contracts/adapters/OZUUPSAccessControlAdapter.sol/OZUUPSAccessControlAdapter.json')
 export const OZTransparentAdapterArtifact = require('../artifacts/contracts/adapters/OZTransparentAdapter.sol/OZTransparentAdapter.json')
 export const DefaultGasPriceCalculatorArtifact = require('../artifacts/contracts/DefaultGasPriceCalculator.sol/DefaultGasPriceCalculator.json')
+export const DefaultCreate2Artifact = require('../artifacts/contracts/DefaultCreate2.sol/DefaultCreate2.json')
 
 const directoryPath = path.join(__dirname, '../artifacts/build-info')
 const fileNames = fs.readdirSync(directoryPath)
@@ -39,3 +40,4 @@ export const OZUUPSAccessControlAdapterABI =
 export const OZTransparentAdapterABI = OZTransparentAdapterArtifact.abi
 export const DefaultGasPriceCalculatorABI =
   DefaultGasPriceCalculatorArtifact.abi
+export const DefaultCreate2ABI = DefaultCreate2Artifact.abi

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -19,6 +19,7 @@ import {
   ManagedServiceArtifact,
   ChugSplashManagerABI,
   DEFAULT_GAS_PRICE_CALCULATOR_ADDRESS,
+  DEFAULT_CREATE2_ADDRESS,
 } from '@chugsplash/contracts'
 import { utils, constants } from 'ethers'
 import { CustomChain } from '@nomiclabs/hardhat-etherscan/dist/src/types'
@@ -96,6 +97,7 @@ export const CURRENT_CHUGSPLASH_MANAGER_VERSION = {
 
 export const managerConstructorValues = [
   CHUGSPLASH_REGISTRY_ADDRESS,
+  DEFAULT_CREATE2_ADDRESS,
   DEFAULT_GAS_PRICE_CALCULATOR_ADDRESS,
   MANAGED_SERVICE_ADDRESS,
   EXECUTION_LOCK_TIME,

--- a/packages/core/src/languages/solidity/predeploys.ts
+++ b/packages/core/src/languages/solidity/predeploys.ts
@@ -35,6 +35,9 @@ import {
   DefaultGasPriceCalculatorABI,
   DefaultGasPriceCalculatorArtifact,
   DEFAULT_GAS_PRICE_CALCULATOR_ADDRESS,
+  DefaultCreate2Artifact,
+  DefaultCreate2ABI,
+  DEFAULT_CREATE2_ADDRESS,
 } from '@chugsplash/contracts'
 import { Logger } from '@eth-optimism/common-ts'
 
@@ -74,6 +77,23 @@ export const initializeChugSplash = async (
   deployer: ethers.Signer,
   logger?: Logger
 ): Promise<void> => {
+  logger?.info('[ChugSplash]: deploying DefaultGasPriceCalculator...')
+
+  const DefaultCreate2 = await doDeterministicDeploy(provider, {
+    signer: deployer,
+    contract: {
+      abi: DefaultCreate2ABI,
+      bytecode: DefaultCreate2Artifact.bytecode,
+    },
+    args: [],
+    salt: ethers.constants.HashZero,
+  })
+
+  assert(
+    DEFAULT_CREATE2_ADDRESS === DefaultCreate2.address,
+    'DefaultGasPriceCalculator has incorrect address'
+  )
+
   logger?.info('[ChugSplash]: deploying DefaultGasPriceCalculator...')
 
   const DefaultGasPriceCalculator = await doDeterministicDeploy(provider, {

--- a/packages/plugins/test/foundry/ChugSplash.t.sol
+++ b/packages/plugins/test/foundry/ChugSplash.t.sol
@@ -14,6 +14,7 @@ import { IChugSplashManager } from "@chugsplash/contracts/contracts/interfaces/I
 import { IProxyAdapter } from "@chugsplash/contracts/contracts/interfaces/IProxyAdapter.sol";
 import { IProxyUpdater } from "@chugsplash/contracts/contracts/interfaces/IProxyUpdater.sol";
 import { IGasPriceCalculator } from "@chugsplash/contracts/contracts/interfaces/IGasPriceCalculator.sol";
+import { ICreate2 } from "@chugsplash/contracts/contracts/interfaces/ICreate2.sol";
 
 /* ChugSplash Foundry Library Tests
  *


### PR DESCRIPTION
This allows us to support non-standard Create2 formulas used by networks like ZK Sync.

Also includes some changes to fit the ChugSplashManager under the contract size limit.