### PR TITLE
refactor(ct,core): clean up contracts, merkle tree generation, and execution logic

### DIFF
--- a/packages/contracts/contracts/ChugSplashManager.sol
+++ b/packages/contracts/contracts/ChugSplashManager.sol
@@ -814,15 +814,12 @@ contract ChugSplashManager is
             // Get the adapter for this reference name.
             address adapter = registry.adapters(action.contractKindHash);
 
-            require(
-                action.contractKindHash == NO_PROXY_CONTRACT_KIND_HASH || adapter != address(0),
-                "ChugSplashManager: proxy type has no adapter"
-            );
-            require(
-                action.contractKindHash != NO_PROXY_CONTRACT_KIND_HASH ||
-                    action.actionType != ChugSplashActionType.SET_STORAGE,
-                "ChugSplashManager: cannot set storage in non-proxied contracts"
-            );
+            action.contractKindHash == NO_PROXY_CONTRACT_KIND_HASH
+                ? require(
+                    action.actionType == ChugSplashActionType.DEPLOY_CONTRACT,
+                    "ChugSplashManager: invalid action type for non-proxy contract"
+                )
+                : require(adapter != address(0), "ChugSplashManager: proxy type has no adapter");
 
             // Mark the action as executed and update the total number of executed actions.
             bundle.actionsExecuted++;

--- a/packages/contracts/contracts/ChugSplashManagerProxy.sol
+++ b/packages/contracts/contracts/ChugSplashManagerProxy.sol
@@ -17,9 +17,9 @@ contract ChugSplashManagerProxy is Proxy {
     ChugSplashRegistry public immutable registry;
 
     modifier isNotExecuting() {
+        address impl = _getImplementation();
         require(
-            _getImplementation() == address(0) ||
-                !IChugSplashManager(_getImplementation()).isExecuting(),
+            impl == address(0) || !IChugSplashManager(impl).isExecuting(),
             "ChugSplashManagerProxy: execution in progress"
         );
         _;

--- a/packages/core/src/actions/execute.ts
+++ b/packages/core/src/actions/execute.ts
@@ -1,7 +1,6 @@
 import { ethers } from 'ethers'
 import { Logger } from '@eth-optimism/common-ts'
 
-import { fromRawChugSplashAction, isDeployContractAction } from './bundle'
 import {
   BundledChugSplashAction,
   ChugSplashBundles,
@@ -163,13 +162,6 @@ export const executeTask = async (args: {
     }
   }
 
-  // Find the indices of the first DeployContract and SetImpl actions so we know where to
-  // split up our batches. Actions have already been sorted in the order: SetStorage then
-  // DeployContract.
-  const firstDepImpl = actionBundle.actions.findIndex((action) =>
-    isDeployContractAction(fromRawChugSplashAction(action.action))
-  )
-
   logger?.info(`[ChugSplash]: initiating execution...`)
   await (
     await chugSplashManager.initiateBundleExecution(
@@ -181,15 +173,10 @@ export const executeTask = async (args: {
 
   logger?.info(`[ChugSplash]: execution initiated`)
 
-  // Execute SetStorage actions in batches.
-  logger?.info(`[ChugSplash]: executing SetStorage actions...`)
-  await executeBatchActions(actionBundle.actions.slice(0, firstDepImpl))
-  logger?.info(`[ChugSplash]: executed SetStorage actions`)
-
-  // Execute DeployContract actions in batches.
-  logger?.info(`[ChugSplash]: executing DeployContract actions...`)
-  await executeBatchActions(actionBundle.actions.slice(firstDepImpl))
-  logger?.info(`[ChugSplash]: executed DeployContract actions`)
+  // Execute actions in batches.
+  logger?.info(`[ChugSplash]: executing actions...`)
+  await executeBatchActions(actionBundle.actions)
+  logger?.info(`[ChugSplash]: executed actions`)
 
   logger?.info(`[ChugSplash]: completing execution...`)
   await (


### PR DESCRIPTION
This PR:
* Makes a couple minor nitpicky changes to the contracts
* Refactors the Merkle tree generation logic used by the target and action bundles
* Batches `DeployContract` and `SetStorage` actions to be executed together