### PR TITLE
maint(exec): Add automated testing of remote executor

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -401,12 +401,15 @@ export const claimExecutorPayment = async (
 ) => {
   // The amount to withdraw is the minimum of the executor's debt and the ChugSplashManager's
   // balance.
-  const withdrawAmount = Math.min(
-    await ChugSplashManager.executorDebt(executor.address),
-    await ChugSplashManager.getBalance()
+  const debt = BigNumber.from(
+    await ChugSplashManager.executorDebt(executor.address)
   )
+  const balance = BigNumber.from(
+    await executor.provider.getBalance(ChugSplashManager.address)
+  )
+  const withdrawAmount = debt.lt(balance) ? debt : balance
 
-  if (withdrawAmount > 0) {
+  if (withdrawAmount.gt(0)) {
     await (
       await ChugSplashManager.claimExecutorPayment(
         withdrawAmount,

--- a/packages/executor/.gitignore
+++ b/packages/executor/.gitignore
@@ -1,3 +1,7 @@
 dist/
 .env*
 cache
+.canonical-configs
+artifacts
+cache
+deployments/

--- a/packages/executor/chugsplash/ExecutorTest.config.ts
+++ b/packages/executor/chugsplash/ExecutorTest.config.ts
@@ -1,0 +1,23 @@
+import { UserChugSplashConfig } from '@chugsplash/core'
+import { constants } from 'ethers'
+
+const config: UserChugSplashConfig = {
+  options: {
+    organizationID: constants.HashZero,
+    projectName: 'Remote Executor Test',
+    claimer: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  },
+  contracts: {
+    ExecutorTest: {
+      contract: 'ExecutorTest',
+      variables: {
+        number: 1,
+        stored: true,
+        storageName: 'First',
+        otherStorage: '0x1111111111111111111111111111111111111111',
+      },
+    },
+  },
+}
+
+export default config

--- a/packages/executor/contracts/ExecutorTest.sol
+++ b/packages/executor/contracts/ExecutorTest.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+contract ExecutorTest {
+    uint8 public number;
+    bool public stored;
+    address public otherStorage;
+    string public storageName;
+}

--- a/packages/executor/hardhat.config.ts
+++ b/packages/executor/hardhat.config.ts
@@ -1,0 +1,35 @@
+import { HardhatUserConfig } from 'hardhat/types'
+
+// Hardhat plugins
+import '@nomiclabs/hardhat-ethers'
+import '@chugsplash/plugins'
+
+const config: HardhatUserConfig = {
+  mocha: {
+    timeout: 160000,
+  },
+  solidity: {
+    version: '0.8.15',
+    settings: {
+      outputSelection: {
+        '*': {
+          '*': ['storageLayout'],
+        },
+      },
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+      metadata: {
+        bytecodeHash: 'none',
+      },
+    },
+  },
+  networks: {
+    localhost: {
+      url: 'http://localhost:8545',
+    },
+  },
+}
+
+export default config

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -12,7 +12,12 @@
     "build": "yarn build:ts",
     "build:ts": "tsc -p ./tsconfig.json",
     "clean": "rimraf dist/ ./tsconfig.tsbuildinfo",
-    "test:coverage": "echo 'no tests'",
+    "test:coverage": "apt install lsof && yarn test",
+    "test": "export DISABLE_ANALYTICS=true && yarn test:start-node && yarn test:start-executor && yarn test:run && yarn test:kill",
+    "test:start-node": "npx hardhat node --disable-chugsplash > /dev/null 2>&1 & sleep 5",
+    "test:start-executor": "yarn start > /dev/null 2>&1 & sleep 5",
+    "test:run": "npx hardhat test --skip-deploy --network localhost",
+    "test:kill": "kill $(lsof -t -i:7300) && kill $(lsof -t -i:8545)",
     "lint": "yarn lint:fix && yarn lint:check",
     "lint:fix": "yarn lint:ts:fix",
     "lint:check": "yarn lint:ts:check",
@@ -34,17 +39,20 @@
     "@chugsplash/core": "^0.8.1",
     "@eth-optimism/common-ts": "^0.7.1",
     "@eth-optimism/core-utils": "^0.9.3",
+    "@nomiclabs/hardhat-ethers": "^2.2.3",
     "dotenv": "^16.0.3",
     "ethers": "^5.6.8",
     "ipfs-http-client": "56.0.3",
-    "undici": "^5.12.0"
+    "undici": "^5.12.0",
+    "hardhat": "^2.10.0"
   },
   "dependencies": {
     "@amplitude/node": "^1.10.2",
     "@chugsplash/core": "^0.8.1",
+    "@chugsplash/plugins": "^0.13.0",
     "@nomiclabs/hardhat-etherscan": "^3.1.3",
     "graphql": "^16.6.0",
     "graphql-request": "^5.1.0",
-    "hardhat": "^2.10.0"
+    "chai": "^4.3.7"
   }
 }

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -140,8 +140,17 @@ export class ChugSplashExecutor extends BaseServiceV2<
       executorAddresses.push(w.address)
     }
 
+    const executors = this.state.keys.map(
+      (el) => new ethers.Wallet(el.privateKey).address
+    )
+
     // Deploy the ChugSplash contracts.
-    await ensureChugSplashInitialized(this.state.provider, wallet)
+    await ensureChugSplashInitialized(
+      this.state.provider,
+      wallet,
+      executors,
+      this.logger
+    )
 
     this.logger.info('[ChugSplash]: finished setting up chugsplash')
 

--- a/packages/executor/test/Executor.test.ts
+++ b/packages/executor/test/Executor.test.ts
@@ -1,0 +1,123 @@
+import * as path from 'path'
+import '@chugsplash/plugins'
+
+import hre, { chugsplash } from 'hardhat'
+import { BigNumber, Contract } from 'ethers'
+import {
+  chugsplashApproveAbstractTask,
+  chugsplashClaimAbstractTask,
+  chugsplashFundAbstractTask,
+  chugsplashProposeAbstractTask,
+  readUnvalidatedChugSplashConfig,
+  readValidatedChugSplashConfig,
+} from '@chugsplash/core'
+import { expect } from 'chai'
+
+import { getArtifactPaths } from '../../plugins/dist'
+import { createChugSplashRuntime } from '../../plugins/src/utils'
+
+const configPath = './chugsplash/ExecutorTest.config.ts'
+
+describe('Remote Execution', () => {
+  let ExecutorTest: Contract
+  beforeEach(async () => {
+    const provider = hre.ethers.provider
+    const signer = provider.getSigner()
+    const signerAddress = await signer.getAddress()
+    const canonicalConfigPath = hre.config.paths.canonicalConfigs
+    const deploymentFolder = hre.config.paths.deployments
+
+    const userConfig = await readUnvalidatedChugSplashConfig(configPath)
+
+    const artifactPaths = await getArtifactPaths(
+      hre,
+      userConfig.contracts,
+      hre.config.paths.artifacts,
+      path.join(hre.config.paths.artifacts, 'build-info')
+    )
+
+    const cre = await createChugSplashRuntime(
+      configPath,
+      true,
+      true,
+      hre.config.paths.canonicalConfigs,
+      hre,
+      // if the config parsing fails and exits with code 1, you should flip this to false to see verbose output
+      false
+    )
+
+    const parsedConfig = await readValidatedChugSplashConfig(
+      provider,
+      configPath,
+      artifactPaths,
+      'hardhat',
+      cre,
+      true
+    )
+
+    // claim
+    await chugsplashClaimAbstractTask(
+      provider,
+      signer,
+      parsedConfig,
+      true,
+      signerAddress,
+      'hardhat',
+      cre
+    )
+
+    // fund
+    await chugsplashFundAbstractTask(
+      provider,
+      signer,
+      configPath,
+      BigNumber.from(0),
+      true,
+      artifactPaths,
+      'hardhat',
+      parsedConfig,
+      cre
+    )
+
+    await chugsplashProposeAbstractTask(
+      provider,
+      signer,
+      parsedConfig,
+      configPath,
+      '',
+      'hardhat',
+      artifactPaths,
+      canonicalConfigPath,
+      cre
+    )
+
+    // approve
+    await chugsplashApproveAbstractTask(
+      provider,
+      signer,
+      configPath,
+      true,
+      false,
+      artifactPaths,
+      'hardhat',
+      canonicalConfigPath,
+      deploymentFolder,
+      parsedConfig,
+      cre
+    )
+
+    ExecutorTest = await chugsplash.getContract(
+      parsedConfig.options.projectName,
+      'ExecutorTest'
+    )
+  })
+
+  it('does deploy remotely', async () => {
+    expect(await ExecutorTest.number()).to.equal(1)
+    expect(await ExecutorTest.stored()).to.equal(true)
+    expect(await ExecutorTest.storageName()).to.equal('First')
+    expect(await ExecutorTest.otherStorage()).to.equal(
+      '0x1111111111111111111111111111111111111111'
+    )
+  })
+})

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "@chugsplash/contracts": "^0.6.0",
     "@chugsplash/core": "^0.8.0",
-    "@chugsplash/executor": "^0.8.0",
     "@eth-optimism/contracts": "^0.5.40",
     "@eth-optimism/core-utils": "^0.9.1",
     "@ethereumjs/common": "^3.0.1",

--- a/packages/plugins/src/utils.ts
+++ b/packages/plugins/src/utils.ts
@@ -15,8 +15,7 @@ export const createChugSplashRuntime = async (
   return {
     configPath,
     canonicalConfigPath,
-    remoteExecution:
-      process.env.FORCE_REMOTE_EXECUTION === 'true' ? true : remoteExecution,
+    remoteExecution,
     autoConfirm,
     stream,
     silent,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,7 +1513,7 @@
     "@nomicfoundation/solidity-analyzer-win32-ia32-msvc" "0.1.1"
     "@nomicfoundation/solidity-analyzer-win32-x64-msvc" "0.1.1"
 
-"@nomiclabs/hardhat-ethers@^2.0.6", "@nomiclabs/hardhat-ethers@^2.2.1":
+"@nomiclabs/hardhat-ethers@^2.0.6", "@nomiclabs/hardhat-ethers@^2.2.1", "@nomiclabs/hardhat-ethers@^2.2.3":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.3.tgz#b41053e360c31a32c2640c9a45ee981a7e603fe0"
   integrity sha512-YhzPdzb612X591FOe68q+qXVXGG2ANZRvDo0RRUtimev85rCrAlv/TLMEZw5c+kq9AbzocLTVX/h2jVIFPL9Xg==


### PR DESCRIPTION
## Purpose
- Adds a basic automated test of the remote executor
- Fixes a bug where withdrawing executor payment causes the executor to crash 
- Fixes issue where executors aren't assigned roles during the `initializeChugSplash` function. I resolved this by impersonating the multi-sig and assigning the executors the roles, but we'll need to deal with this on live networks separately.

## Usage
- Run `yarn test` in the executor package
- Runs automatically in our CI process