### PR TITLE
fix(core): ensure storageLayout object is never undefined

### DIFF
--- a/.changeset/perfect-pandas-add.md
+++ b/.changeset/perfect-pandas-add.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Ensure storageLayout field is never undefined

--- a/packages/core/src/actions/artifacts.ts
+++ b/packages/core/src/actions/artifacts.ts
@@ -8,6 +8,7 @@ import {
 import { ParsedChugSplashConfig } from '../config/types'
 import {
   ArtifactPaths,
+  CompilerOutput,
   SolidityStorageLayout,
 } from '../languages/solidity/types'
 import { Integration } from '../constants'
@@ -23,20 +24,18 @@ import {
 import 'core-js/features/array/at'
 
 /**
- * Reads the storageLayout portion of the compiler artifact for a given contract. Reads the
- * artifact from the local file system.
+ * Gets the storage layout for a contract.
  *
  * @param contractFullyQualifiedName Fully qualified name of the contract.
  * @param artifactFolder Relative path to the folder where artifacts are stored.
  * @return Storage layout object from the compiler output.
  */
-export const readStorageLayout = (
-  buildInfoPath: string,
-  contractFullyQualifiedName: string
+export const getStorageLayout = (
+  compilerOutput: CompilerOutput,
+  sourceName: string,
+  contractName: string
 ): SolidityStorageLayout => {
-  const buildInfo = readBuildInfo(buildInfoPath)
-  const [sourceName, contractName] = contractFullyQualifiedName.split(':')
-  const contractOutput = buildInfo.output.contracts[sourceName][contractName]
+  const contractOutput = compilerOutput.contracts[sourceName][contractName]
 
   // Foundry artifacts do not contain the storage layout field for contracts which have no storage.
   // So we default to an empty storage layout in this case for consistency.
@@ -133,8 +132,12 @@ export const writeDeploymentArtifacts = async (
         referenceName,
         abi
       )
-      const { metadata, storageLayout } =
-        buildInfo.output.contracts[sourceName][contractName]
+      const { metadata } = buildInfo.output.contracts[sourceName][contractName]
+      const storageLayout = getStorageLayout(
+        buildInfo.output,
+        sourceName,
+        contractName
+      )
       const { devdoc, userdoc } =
         typeof metadata === 'string'
           ? JSON.parse(metadata).output

--- a/packages/core/src/actions/bundle.ts
+++ b/packages/core/src/actions/bundle.ts
@@ -32,6 +32,7 @@ import {
   RawChugSplashAction,
   SetStorageAction,
 } from './types'
+import { getStorageLayout } from './artifacts'
 
 /**
  * Checks whether a given action is a SetStorage action.
@@ -334,9 +335,11 @@ export const makeActionBundleFromConfig = async (
       contractName,
     } = artifacts[referenceName]
 
-    // Foundry outputs no storage layout for contracts that don't have any storage variables, so we fill it in with the empty layout.
-    const storageLayout = compilerOutput.contracts[sourceName][contractName]
-      .storageLayout ?? { storage: [], types: {} }
+    const storageLayout = getStorageLayout(
+      compilerOutput,
+      sourceName,
+      contractName
+    )
 
     // Skip adding a `DEPLOY_CONTRACT` action if the contract has already been deployed.
     if (

--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -71,6 +71,7 @@ import {
   buildMappingStorageObj,
 } from '../languages/solidity/iterator'
 import { ChugSplashRuntimeEnvironment } from '../types'
+import { getStorageLayout } from '../actions/artifacts'
 
 class InputError extends Error {
   constructor(message: string) {
@@ -2054,8 +2055,11 @@ const assertValidContractVariables = (
       const { sourceName, contractName } = artifact
 
       const compilerOutput = cachedCompilerOutput[referenceName]
-      const storageLayout =
-        compilerOutput.contracts[sourceName][contractName].storageLayout
+      const storageLayout = getStorageLayout(
+        compilerOutput,
+        sourceName,
+        contractName
+      )
 
       const parsedContractVariables = parseContractVariables(
         JSON.parse(

--- a/packages/core/src/languages/solidity/types.ts
+++ b/packages/core/src/languages/solidity/types.ts
@@ -94,7 +94,7 @@ export interface CompilerOutputMetadata {
 
 export interface CompilerOutputContract {
   abi: Array<Fragment>
-  storageLayout: SolidityStorageLayout
+  storageLayout?: SolidityStorageLayout
   evm: {
     bytecode: CompilerOutputBytecode
     deployedBytecode: CompilerOutputBytecode


### PR DESCRIPTION
Previously, we were using the `storageLayout` object in our codebase without taking into consideration that it may be undefined when using Foundry. This PR fixes that issue by using `getStorageLayout` throughout our codebase.