### PR TITLE
fix(core): Improve gas estimation logic

### DIFF
--- a/packages/core/src/actions/artifacts.ts
+++ b/packages/core/src/actions/artifacts.ts
@@ -129,7 +129,6 @@ export const writeDeploymentArtifacts = async (
       )
       const { constructorArgValues } = getConstructorArgs(
         parsedConfig.contracts[referenceName].constructorArgs,
-        referenceName,
         abi
       )
       const { metadata } = buildInfo.output.contracts[sourceName][contractName]

--- a/packages/core/src/actions/bundle.ts
+++ b/packages/core/src/actions/bundle.ts
@@ -276,7 +276,6 @@ export const bundleLocal = async (
     const creationCodeWithConstructorArgs = getCreationCodeWithConstructorArgs(
       bytecode,
       contractConfig.constructorArgs,
-      referenceName,
       abi
     )
     artifacts[referenceName] = {

--- a/packages/core/src/etherscan.ts
+++ b/packages/core/src/etherscan.ts
@@ -90,7 +90,6 @@ export const verifyChugSplashConfig = async (
     const { abi, contractName, sourceName } = artifact
     const { constructorArgValues } = getConstructorArgs(
       canonicalConfig.contracts[referenceName].constructorArgs,
-      referenceName,
       abi
     )
     const implementationAddress = getContractAddress(

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -90,9 +90,7 @@ export const monitorExecution = async (
       provider,
       bundles,
       bundleState.actionsExecuted.toNumber(),
-      claimer,
-      organizationID,
-      projectName,
+      parsedConfig,
       false
     )
     if (amountToDeposit.gt(0)) {

--- a/packages/core/src/languages/solidity/predeploys.ts
+++ b/packages/core/src/languages/solidity/predeploys.ts
@@ -40,7 +40,6 @@ import {
   DEFAULT_CREATE2_ADDRESS,
 } from '@chugsplash/contracts'
 import { Logger } from '@eth-optimism/common-ts'
-import { toUtf8Bytes } from 'ethers/lib/utils'
 
 import {
   isContractDeployed,

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -203,9 +203,7 @@ export const chugsplashProposeAbstractTask = async (
       provider,
       bundles,
       0,
-      parsedConfig.options.claimer,
-      parsedConfig.options.organizationID,
-      parsedConfig.options.projectName,
+      parsedConfig,
       true
     )
 
@@ -542,9 +540,7 @@ export const chugsplashFundAbstractTask = async (
     provider,
     await bundleLocal(provider, parsedConfig, artifactPaths, integration),
     0,
-    parsedConfig.options.claimer,
-    parsedConfig.options.organizationID,
-    parsedConfig.options.projectName,
+    parsedConfig,
     true
   )
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -830,7 +830,6 @@ export const getContractAddress = (
   const creationCodeWithConstructorArgs = getCreationCodeWithConstructorArgs(
     bytecode,
     constructorArgs ?? {},
-    referenceName,
     abi
   )
 
@@ -843,7 +842,6 @@ export const getContractAddress = (
 
 export const getConstructorArgs = (
   constructorArgs: UserConfigVariables,
-  referenceName: string,
   abi: Array<Fragment>
 ): {
   constructorArgTypes: Array<string>
@@ -872,12 +870,10 @@ export const getConstructorArgs = (
 export const getCreationCodeWithConstructorArgs = (
   bytecode: string,
   constructorArgs: UserConfigVariables,
-  referenceName: string,
   abi: any
 ): string => {
   const { constructorArgTypes, constructorArgValues } = getConstructorArgs(
     constructorArgs,
-    referenceName,
     abi
   )
 
@@ -1238,7 +1234,6 @@ export const getCanonicalConfigArtifacts = async (
           getCreationCodeWithConstructorArgs(
             add0x(contractOutput.evm.bytecode.object),
             contractConfig.constructorArgs,
-            referenceName,
             contractOutput.abi
           )
 

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -59,7 +59,7 @@ export class ChugSplashExecutor extends BaseServiceV2<
           desc: 'Command delimited list of private keys for signing deployment transactions',
           validator: validators.str,
           default:
-            '0xdf57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e',
+            '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
         },
         logLevel: {
           desc: 'Executor log level',

--- a/packages/executor/src/utils/execute.ts
+++ b/packages/executor/src/utils/execute.ts
@@ -155,7 +155,7 @@ export const handleExecution = async (data: ExecutorMessage) => {
     const retryEvent = generateRetryEvent(executorEvent)
     process.send({ action: 'retry', payload: retryEvent })
   }
-  const { projectName, organizationID, claimer } = canonicalConfig.options
+  const { projectName, organizationID } = canonicalConfig.options
 
   const expectedBundleId = computeBundleId(
     bundles.actionBundle.root,
@@ -231,12 +231,11 @@ export const handleExecution = async (data: ExecutorMessage) => {
       rpcProvider,
       bundles,
       bundleState.actionsExecuted.toNumber(),
-      claimer,
-      organizationID,
-      projectName
+      canonicalConfig
     )
   ) {
     logger.info(`[ChugSplash]: ${projectName} has sufficient funds`)
+
     // execute bundle
     try {
       await executeTask({


### PR DESCRIPTION
## Purpose
Improves our off-chain gas cost estimation logic

- Only includes the cost of deploying a proxy if a proxy has not yet been deployed
- Does not include the cost of deploying any implementation contracts that have already been deployed
- Adds a fixed buffer of 150k to account for the initiate and complete function calls

## Testing
Tested using the remote executor with various cases including Rabbitholes contracts and a bunch of our test configs from the plugins package. 