### PR TITLE
fix(ct): assert contracts are below the contract size limit

### DIFF
--- a/.changeset/hot-lies-walk.md
+++ b/.changeset/hot-lies-walk.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Assert that the contracts in the config are below the contract size limit

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -24,6 +24,8 @@ import {
 import { utils, constants } from 'ethers'
 import { CustomChain } from '@nomiclabs/hardhat-etherscan/dist/src/types'
 
+export const CONTRACT_SIZE_LIMIT = 24576 // bytes
+
 // Etherscan constants
 export const customChains: CustomChain[] = []
 

--- a/packages/core/src/fund.ts
+++ b/packages/core/src/fund.ts
@@ -113,9 +113,9 @@ export const estimateExecutionGas = async (
       ethers.BigNumber.from(0)
     )
 
-  // We also tack on an extra 100k gas for each proxy target (including any that are not being upgraded) to account
+  // We also tack on an extra 200k gas for each proxy target (including any that are not being upgraded) to account
   // for the variable cost of the `initiateBundleExecution` and `completeBundleExecution` functions.
-  const initiateAndCompleteCost = ethers.BigNumber.from(100_000).mul(
+  const initiateAndCompleteCost = ethers.BigNumber.from(200_000).mul(
     bundles.targetBundle.targets.length
   )
 

--- a/packages/core/src/languages/solidity/types.ts
+++ b/packages/core/src/languages/solidity/types.ts
@@ -81,6 +81,7 @@ export type ContractArtifact = {
   sourceName: string
   contractName: string
   bytecode: string
+  deployedBytecode: string
 }
 
 export interface CompilerOutputMetadata {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -761,13 +761,14 @@ export const readBuildInfo = (buildInfoPath: string): BuildInfo => {
  */
 export const parseFoundryArtifact = (artifact: any): ContractArtifact => {
   const abi = artifact.abi
-  const bytecode = artifact.bytecode.object
+  const bytecode = add0x(artifact.bytecode.object)
+  const deployedBytecode = add0x(artifact.deployedBytecode.object)
 
   const compilationTarget = artifact.metadata.settings.compilationTarget
   const sourceName = Object.keys(compilationTarget)[0]
   const contractName = compilationTarget[sourceName]
 
-  return { abi, bytecode, sourceName, contractName }
+  return { abi, bytecode, sourceName, contractName, deployedBytecode }
 }
 
 export const isEqualType = (
@@ -1227,6 +1228,7 @@ export const getConfigArtifactsRemote = async (
             sourceName,
             contractName,
             bytecode: add0x(contractOutput.evm.bytecode.object),
+            deployedBytecode: add0x(contractOutput.evm.deployedBytecode.object),
           },
         }
       }


### PR DESCRIPTION
Also changes the estimate of an initiation + completion call from 100k to 200k. This is based on the cost of initiating the contract in the demo package without deploying the default proxy. This cost 100k, so the cost of initiating and completing a contract is 200k assuming that the completion tx costs the same as the initiation tx.