### PR TITLE
maint(core): Update system Etherscan verification logic

### DIFF
--- a/packages/core/hardhat.config.ts
+++ b/packages/core/hardhat.config.ts
@@ -59,6 +59,11 @@ const config: HardhatUserConfig = {
       url: `https://arb-goerli.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
       accounts,
     },
+    polygonMumbai: {
+      chainId: 80001,
+      url: `https://polygon-mumbai.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
+      accounts,
+    },
   },
 }
 

--- a/packages/core/scripts/deploy.ts
+++ b/packages/core/scripts/deploy.ts
@@ -1,12 +1,17 @@
 import { Logger } from '@eth-optimism/common-ts'
 import hre from 'hardhat'
+import { getChainId } from '@openzeppelin/upgrades-core'
 import '@nomiclabs/hardhat-ethers'
 
-import { initializeChugSplash } from '../dist'
+import {
+  initializeChugSplash,
+  isSupportedNetworkOnEtherscan,
+  verifyChugSplash,
+} from '../dist'
 
 const main = async () => {
   // Set executors to passed in addresses or default to the signer's address
-  const args = process.argv.slice(2)
+  const args = process.argv.slice(4)
   const executors =
     args.length > 0
       ? args
@@ -16,12 +21,44 @@ const main = async () => {
     name: 'deploy',
   })
   const provider = hre.ethers.provider
+
+  // Deploy Contracts
   await initializeChugSplash(
     provider,
     await provider.getSigner(),
     executors,
     logger
   )
+
+  // Verify ChugSplash contracts on etherscan
+  try {
+    // Verify the ChugSplash contracts if the current network is supported.
+    if (isSupportedNetworkOnEtherscan(await getChainId(provider))) {
+      const apiKey = process.env.ETHERSCAN_API_KEY
+      if (apiKey) {
+        logger.info(
+          '[ChugSplash]: attempting to verify the chugsplash contracts...'
+        )
+        await verifyChugSplash(provider, provider.network.name, apiKey)
+        logger.info(
+          '[ChugSplash]: finished attempting to verify the chugsplash contracts'
+        )
+      } else {
+        logger.info(
+          `[ChugSplash]: skipped verifying chugsplash contracts. reason: no api key found`
+        )
+      }
+    } else {
+      logger.info(
+        `[ChugSplash]: skipped verifying chugsplash contracts. reason: etherscan config not detected for: ${provider.network.name}`
+      )
+    }
+  } catch (e) {
+    logger.error(
+      `[ChugSplash]: error: failed to verify chugsplash contracts on ${provider.network.name}`,
+      e
+    )
+  }
 }
 
 // We recommend this pattern to be able to use async/await everywhere

--- a/packages/core/src/addresses.ts
+++ b/packages/core/src/addresses.ts
@@ -20,6 +20,8 @@ import {
   DefaultUpdaterArtifact,
   OZUUPSUpdaterArtifact,
   OZTransparentAdapterArtifact,
+  DefaultCreate2Artifact,
+  DefaultGasPriceCalculatorArtifact,
 } from '@chugsplash/contracts'
 import { constants, utils } from 'ethers'
 
@@ -34,6 +36,10 @@ const OZUUPSAccessControlAdapterSourceName =
 const defaultUpdaterSourceName = DefaultUpdaterArtifact.sourceName
 const OZUUPSUpdaterSourceName = OZUUPSUpdaterArtifact.sourceName
 const OZTransparentAdapterSourceName = OZTransparentAdapterArtifact.sourceName
+const DefaultCreate2SourceName = DefaultCreate2Artifact.sourceName
+const DefaultGasPriceCalculatorSourceName =
+  DefaultGasPriceCalculatorArtifact.sourceName
+const ManagedServiceSourceName = ManagedServiceArtifact.sourceName
 
 export const getRegistryConstructorValues = () => [getOwnerAddress()]
 
@@ -107,11 +113,7 @@ export const getChugSplashManagerV1Address = () =>
 
 export const getChugSplashConstructorArgs = () => {
   return {
-    [chugsplashRegistrySourceName]: [
-      OWNER_BOND_AMOUNT,
-      EXECUTION_LOCK_TIME,
-      EXECUTOR_PAYMENT_PERCENTAGE,
-    ],
+    [chugsplashRegistrySourceName]: [getOwnerAddress()],
     [chugsplashManagerSourceName]: getManagerConstructorValues(),
     [defaultAdapterSourceName]: [DEFAULT_UPDATER_ADDRESS],
     [OZUUPSOwnableAdapterSourceName]: [OZ_UUPS_UPDATER_ADDRESS],
@@ -119,5 +121,8 @@ export const getChugSplashConstructorArgs = () => {
     [OZTransparentAdapterSourceName]: [DEFAULT_UPDATER_ADDRESS],
     [defaultUpdaterSourceName]: [],
     [OZUUPSUpdaterSourceName]: [],
+    [DefaultCreate2SourceName]: [],
+    [DefaultGasPriceCalculatorSourceName]: [],
+    [ManagedServiceSourceName]: [getOwnerAddress()],
   }
 }

--- a/packages/core/src/etherscan.ts
+++ b/packages/core/src/etherscan.ts
@@ -36,6 +36,11 @@ import {
   OZ_UUPS_OWNABLE_ADAPTER_ADDRESS,
   OZ_UUPS_ACCESS_CONTROL_ADAPTER_ADDRESS,
   ChugSplashManagerArtifact,
+  DefaultCreate2Artifact,
+  DEFAULT_CREATE2_ADDRESS,
+  DefaultGasPriceCalculatorArtifact,
+  DEFAULT_GAS_PRICE_CALCULATOR_ADDRESS,
+  ManagedServiceArtifact,
 } from '@chugsplash/contracts'
 import { request } from 'undici'
 import { CompilerInput } from 'hardhat/types'
@@ -45,6 +50,7 @@ import {
   getChugSplashConstructorArgs,
   getChugSplashRegistryAddress,
   getChugSplashManagerV1Address,
+  getManagedServiceAddress,
 } from './addresses'
 import { CanonicalChugSplashConfig } from './config/types'
 import {
@@ -160,16 +166,14 @@ export const verifyChugSplash = async (
 
   const contracts = [
     {
+      artifact: ChugSplashRegistryArtifact,
+      address: getChugSplashRegistryAddress(),
+    },
+    {
       artifact: ChugSplashManagerArtifact,
       address: getChugSplashManagerV1Address(),
     },
-    { artifact: DefaultUpdaterArtifact, address: DEFAULT_UPDATER_ADDRESS },
     { artifact: DefaultAdapterArtifact, address: DEFAULT_ADAPTER_ADDRESS },
-    {
-      artifact: OZTransparentAdapterArtifact,
-      address: OZ_TRANSPARENT_ADAPTER_ADDRESS,
-    },
-    { artifact: OZUUPSUpdaterArtifact, address: OZ_UUPS_UPDATER_ADDRESS },
     {
       artifact: OZUUPSOwnableAdapterArtifact,
       address: OZ_UUPS_OWNABLE_ADAPTER_ADDRESS,
@@ -179,10 +183,17 @@ export const verifyChugSplash = async (
       address: OZ_UUPS_ACCESS_CONTROL_ADAPTER_ADDRESS,
     },
     {
-      artifact: ChugSplashRegistryArtifact,
-      address: getChugSplashRegistryAddress(),
+      artifact: OZTransparentAdapterArtifact,
+      address: OZ_TRANSPARENT_ADAPTER_ADDRESS,
     },
-    { artifact: DefaultAdapterArtifact, address: DEFAULT_ADAPTER_ADDRESS },
+    { artifact: DefaultUpdaterArtifact, address: DEFAULT_UPDATER_ADDRESS },
+    { artifact: OZUUPSUpdaterArtifact, address: OZ_UUPS_UPDATER_ADDRESS },
+    { artifact: DefaultCreate2Artifact, address: DEFAULT_CREATE2_ADDRESS },
+    {
+      artifact: DefaultGasPriceCalculatorArtifact,
+      address: DEFAULT_GAS_PRICE_CALCULATOR_ADDRESS,
+    },
+    { artifact: ManagedServiceArtifact, address: getManagedServiceAddress() },
   ]
 
   for (const { artifact, address } of contracts) {
@@ -211,15 +222,6 @@ export const verifyChugSplash = async (
       chugSplashConstructorArgs[sourceName]
     )
   }
-
-  // Link the ChugSplashRegistry's implementation with its proxy
-  await linkProxyWithImplementation(
-    etherscanApiEndpoints.urls,
-    apiKey,
-    getChugSplashRegistryAddress(),
-    getChugSplashRegistryAddress(),
-    'ChugSplashRegistry'
-  )
 }
 
 export const attemptVerification = async (

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -17,11 +17,8 @@ import {
   ExecutorState,
   ExecutorEvent,
   ExecutorKey,
-  isSupportedNetworkOnEtherscan,
-  verifyChugSplash,
   ensureChugSplashInitialized,
 } from '@chugsplash/core'
-import { getChainId } from '@eth-optimism/core-utils'
 import { GraphQLClient } from 'graphql-request'
 
 import { ExecutorMessage, ResponseMessage } from './utils/execute'
@@ -153,42 +150,6 @@ export class ChugSplashExecutor extends BaseServiceV2<
     )
 
     this.logger.info('[ChugSplash]: finished setting up chugsplash')
-
-    // verify ChugSplash contracts on etherscan
-    try {
-      // Verify the ChugSplash contracts if the current network is supported.
-      if (
-        isSupportedNetworkOnEtherscan(await getChainId(this.state.provider))
-      ) {
-        const apiKey = process.env.ETHERSCAN_API_KEY
-        if (apiKey) {
-          this.logger.info(
-            '[ChugSplash]: attempting to verify the chugsplash contracts...'
-          )
-          await verifyChugSplash(
-            this.state.provider,
-            this.options.network,
-            apiKey
-          )
-          this.logger.info(
-            '[ChugSplash]: finished attempting to verify the chugsplash contracts'
-          )
-        } else {
-          this.logger.info(
-            `[ChugSplash]: skipped verifying chugsplash contracts. reason: no api key found`
-          )
-        }
-      } else {
-        this.logger.info(
-          `[ChugSplash]: skipped verifying chugsplash contracts. reason: etherscan config not detected for: ${this.options.network}`
-        )
-      }
-    } catch (e) {
-      this.logger.error(
-        `[ChugSplash]: error: failed to verify chugsplash contracts on ${this.options.network}`,
-        e
-      )
-    }
   }
 
   async main() {


### PR DESCRIPTION
## Purpose
Updates Etherscan verification logic for the main ChugSplash contracts. 

Note: This does not include logic for verifying default proxies. I've created a [separate ticket](https://linear.app/chugsplash/issue/CHU-221/verify-default-proxies-on-etherscan) for that b/c I believe it's a bit more involved than just verifying `Proxy.sol`. 