### PR TITLE
fix(core): assert valid bundle size

### DIFF
--- a/.changeset/sharp-rats-protect.md
+++ b/.changeset/sharp-rats-protect.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Assert valid bundle size

--- a/packages/core/src/fund.ts
+++ b/packages/core/src/fund.ts
@@ -80,10 +80,10 @@ export const estimateExecutionGas = async (
 
   const deployedProxyPromises = Object.values(parsedConfig.contracts).map(
     async (contract) =>
-      // If the proxy has already been deployed, then estimate 0 gas. Otherwise, estimate 550k for the default proxy.
-      (await isContractDeployed(contract.address, provider))
-        ? ethers.BigNumber.from(0)
-        : ethers.BigNumber.from(550_000)
+      contract.kind === 'internal-default' &&
+      !(await isContractDeployed(contract.address, provider))
+        ? ethers.BigNumber.from(550_000)
+        : ethers.BigNumber.from(0)
   )
 
   const deployedContractPromises = actions


### PR DESCRIPTION
This PR adds an assertion that checks if a bundle is too large to be executed. This is determined by estimating the gas used during the initiation txn, which is the limiting factor in this situation, because it must occur in a single transaction, unlike `executeActions`.