### PR TITLE
fix(core): assert block gas limit is sufficiently high in parsing logic

### DIFF
--- a/.changeset/khaki-bees-leave.md
+++ b/.changeset/khaki-bees-leave.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/core': patch
+---
+
+Assert block gas limit is sufficiently high in parsing logic

--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -47,6 +47,7 @@ import {
   isDataHexString,
   isLiveNetwork,
   isContractDeployed,
+  assertValidBlockGasLimit,
 } from '../utils'
 import {
   UserChugSplashConfig,
@@ -2140,6 +2141,8 @@ export const parseAndValidateChugSplashConfig = async (
 
   // If the user disabled some safety checks, log warnings related to that
   logUnsafeOptions(userConfig, cre.silent, cre.stream)
+
+  await assertValidBlockGasLimit(provider)
 
   // Validate top level config and contract options
   await assertValidUserConfigFields(userConfig, provider, cre, exitOnFailure)

--- a/packages/core/src/languages/solidity/predeploys.ts
+++ b/packages/core/src/languages/solidity/predeploys.ts
@@ -47,6 +47,7 @@ import {
   getGasPriceOverrides,
   isLiveNetwork,
   getImpersonatedSigner,
+  assertValidBlockGasLimit,
 } from '../../utils'
 import { EXECUTOR_ROLE } from '../../constants'
 import {
@@ -82,12 +83,7 @@ export const initializeChugSplash = async (
   executors: string[],
   logger?: Logger
 ): Promise<void> => {
-  // Check that the block gas limit is reasonably high on this network. Although we can lower 15M to
-  // 10M or less, we err on the side of safety for now. This number should never be lower than 6M
-  // because it costs ~5.3M gas to deploy the ChugSplashManager V1, which is at the contract size
-  // limit.
-  const { gasLimit: blockGasLimit } = await provider.getBlock('latest')
-  assert(blockGasLimit.gte(15_000_000), `Block gas limit is too low.`)
+  await assertValidBlockGasLimit(provider)
 
   const chugsplashConstructorArgs = getChugSplashConstructorArgs()
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1298,3 +1298,21 @@ export const getImpersonatedSigner = async (
 
   return provider.getSigner(address)
 }
+
+/**
+ * Assert that the block gas limit is reasonably high on a network.
+ */
+export const assertValidBlockGasLimit = async (
+  provider: providers.Provider
+) => {
+  const { gasLimit: blockGasLimit } = await provider.getBlock('latest')
+
+  // Although we can lower this from 15M to 10M or less, we err on the side of safety for now. This
+  //  number should never be lower than 5.5M because it costs ~5.3M gas to deploy the
+  //  ChugSplashManager V1, which is at the contract size limit.
+  if (blockGasLimit.lt(15_000_000)) {
+    throw new Error(
+      `Block gas limit is too low. Got: ${blockGasLimit.toString()}. Expected: 15M+`
+    )
+  }
+}


### PR DESCRIPTION
This PR extends #648 to assert that the block gas limit is > 15M in the parsing logic. I've included this because live networks may change their block gas limit over time. For example, [ZK Sync's is 2^32 - 1](https://era.zksync.io/docs/dev/developer-guides/transactions/blocks.html#block-properties), but they plan to change it in the relatively near future.