### PR TITLE
maint: rename bundle to deployment in certain contexts

### DIFF
--- a/docs/how-chugsplash-works.md
+++ b/docs/how-chugsplash-works.md
@@ -120,7 +120,7 @@ In addition to committing this info to IPFS, the user also submits a single `pro
 2. The root of the Merkle tree. Each Merkle proof supplied by the executor must yield this Merkle root.
 3. The number of leafs in the Merkle tree (i.e. the number of `SetStorage` and `DeployImplementation` actions). It's necessary to explicitly specify this to ensure that each action is only executed exactly once.
 
-These three inputs are hashed to yield a 32-byte **bundle ID**, which is the unique identifier for the entire deployment. This bundle will be approved by the project's owner during the next step. It's called a bundle ID because the set of `DeployImplementation` and `SetStorage` actions are referred to as a bundle internally.
+These three inputs are hashed to yield a 32-byte **deployment ID**, which is the unique identifier for the entire deployment. This deployment will be approved by the project's owner during the next step.
 
 As a side effect of using `SetStorage` actions, it becomes easy to view the effects of a proposed upgrade as a git-style diff against the existing system, including state variables, before the upgrade occurs. This specific feature is not available yet, and will be implemented soon.
 
@@ -128,7 +128,7 @@ This entire process occurs in a single `propose` command, which is available as 
 
 ### Approval
 
-Once a team has decided to proceed with a deployment or upgrade, the proposed deployment is approved by the project's owner, which is usually governance or a multisig. This occurs via an `approve` transaction on the project's `ChugSplashManager`. This transaction has a single input: the 32-byte bundle ID created in the proposal step.
+Once a team has decided to proceed with a deployment or upgrade, the proposed deployment is approved by the project's owner, which is usually governance or a multisig. This occurs via an `approve` transaction on the project's `ChugSplashManager`. This transaction has a single input: the 32-byte deployment ID created in the proposal step.
 
 ### Execution
 

--- a/packages/contracts/contracts/ChugSplashDataTypes.sol
+++ b/packages/contracts/contracts/ChugSplashDataTypes.sol
@@ -2,34 +2,10 @@
 pragma solidity ^0.8.15;
 
 /**
- * @notice Struct representing an entire ChugSplash bundle.
+ * @notice Struct representing the state of a ChugSplash deployment.
  */
-struct ChugSplashBundle {
-    ChugSplashActionWithProof[] actions;
-    bytes32 root;
-}
-
-/**
- * @notice Struct representing a single ChugSplash action along with its Merkle proof.
- */
-struct ChugSplashActionWithProof {
-    ChugSplashAction action;
-    ChugSplashProof proof;
-}
-
-/**
- * @notice Struct representing a Merkle proof for a single ChugSplash action.
- */
-struct ChugSplashProof {
-    uint256 actionIndex;
-    bytes32[] siblings;
-}
-
-/**
- * @notice Struct representing the state of a ChugSplash bundle.
- */
-struct ChugSplashBundleState {
-    ChugSplashBundleStatus status;
+struct DeploymentState {
+    DeploymentStatus status;
     bool[] actions;
     uint256 targets;
     bytes32 actionRoot;
@@ -73,7 +49,7 @@ enum ChugSplashActionType {
 /**
  * @notice Enum representing the status of a given ChugSplash action.
  */
-enum ChugSplashBundleStatus {
+enum DeploymentStatus {
     EMPTY,
     PROPOSED,
     APPROVED,

--- a/packages/contracts/test/MockChugSplashManager.sol
+++ b/packages/contracts/test/MockChugSplashManager.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.15;
 
 contract MockChugSplashManager {
-    function computeBundleId(bytes32, uint256, string memory) public pure returns (bytes32) {
+    function computeDeploymentId(bytes32, uint256, string memory) public pure returns (bytes32) {
         return bytes32(uint256(1));
     }
 }

--- a/packages/core/src/actions/bundle.ts
+++ b/packages/core/src/actions/bundle.ts
@@ -172,7 +172,7 @@ export const getTargetHash = (target: ChugSplashTarget): string => {
   )
 }
 
-export const makeBundleFromTargets = (
+export const makeTargetBundle = (
   targets: ChugSplashTarget[]
 ): ChugSplashTargetBundle => {
   // Compute the hash for each action.
@@ -202,7 +202,7 @@ export const makeBundleFromTargets = (
  * @param actions Series of DeployContract and SetStorage actions to bundle.
  * @return Bundled actions.
  */
-export const makeBundleFromActions = (
+export const makeActionBundle = (
   actions: ChugSplashAction[]
 ): ChugSplashActionBundle => {
   // Turn the "nice" action structs into raw actions.
@@ -368,7 +368,7 @@ export const makeActionBundleFromConfig = async (
   }
 
   // Generate a bundle from the list of actions.
-  return makeBundleFromActions(actions)
+  return makeActionBundle(actions)
 }
 
 /**
@@ -410,5 +410,5 @@ export const makeTargetBundleFromConfig = (
   }
 
   // Generate a bundle from the list of actions.
-  return makeBundleFromTargets(targets)
+  return makeTargetBundle(targets)
 }

--- a/packages/core/src/actions/types.ts
+++ b/packages/core/src/actions/types.ts
@@ -11,7 +11,7 @@ export enum ChugSplashActionType {
 /**
  * The status of a given ChugSplash action.
  */
-export enum ChugSplashBundleStatus {
+export enum DeploymentStatus {
   EMPTY,
   PROPOSED,
   APPROVED,
@@ -109,8 +109,8 @@ export interface ChugSplashTargetBundle {
 /**
  * The state of a ChugSplash bundle.
  */
-export type ChugSplashBundleState = {
-  status: ChugSplashBundleStatus
+export type DeploymentState = {
+  status: DeploymentStatus
   actions: boolean[]
   actionRoot: string
   targetRoot: string

--- a/packages/core/src/config/fetch.ts
+++ b/packages/core/src/config/fetch.ts
@@ -3,7 +3,7 @@ import { create, IPFSHTTPClient } from 'ipfs-http-client'
 
 import { ChugSplashBundles } from '../actions/types'
 import { bundleRemoteSubtask } from '../languages/solidity/compiler'
-import { callWithTimeout, computeBundleId } from '../utils'
+import { callWithTimeout, computeDeploymentId } from '../utils'
 import { CanonicalChugSplashConfig } from './types'
 
 export const chugsplashFetchSubtask = async (args: {
@@ -50,10 +50,10 @@ export const chugsplashFetchSubtask = async (args: {
   return config
 }
 
-export const verifyBundle = async (
+export const verifyDeployment = async (
   provider: providers.Provider,
   configUri: string,
-  bundleId: string,
+  deploymentId: string,
   ipfsUrl: string
 ) => {
   const config = await callWithTimeout<CanonicalChugSplashConfig>(
@@ -68,8 +68,8 @@ export const verifyBundle = async (
   })
 
   if (
-    bundleId !==
-    computeBundleId(
+    deploymentId !==
+    computeDeploymentId(
       actionBundle.root,
       targetBundle.root,
       actionBundle.actions.length,
@@ -78,7 +78,7 @@ export const verifyBundle = async (
     )
   ) {
     throw new Error(
-      'Bundle ID generated from downloaded config does NOT match given hash. Please report this error.'
+      'Deployment ID generated from downloaded config does NOT match given hash. Please report this error.'
     )
   }
 }

--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -2188,7 +2188,7 @@ export const parseAndValidateChugSplashConfig = async (
     await assertContractsBelowSizeLimit(parsedConfig, cachedArtifacts, cre)
   }
 
-  await assertValidBundleSize(provider, parsedConfig, cre)
+  await assertValidDeploymentSize(provider, parsedConfig, cre)
 
   // Complete misc pre-deploy validation
   // I.e run storage slot checker + other safety checks, detect if the deployment is an upgrade, etc
@@ -2223,7 +2223,7 @@ export const parseAndValidateChugSplashConfig = async (
 /**
  * Asserts that the ChugSplash config can be initiated in a single transaction.
  */
-export const assertValidBundleSize = async (
+export const assertValidDeploymentSize = async (
   provider: providers.Provider,
   parsedConfig: ParsedChugSplashConfig,
   cre: ChugSplashRuntimeEnvironment

--- a/packages/core/src/fund.ts
+++ b/packages/core/src/fund.ts
@@ -49,7 +49,7 @@ export const getOwnerWithdrawableAmount = async (
   )
 
   if (
-    (await ChugSplashManager.activeBundleId()) !== ethers.constants.HashZero
+    (await ChugSplashManager.activeDeploymentId()) !== ethers.constants.HashZero
   ) {
     return ethers.BigNumber.from(0)
   }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -69,7 +69,7 @@ import {
 import { chugsplashFetchSubtask } from './config/fetch'
 import { getSolcBuild } from './languages'
 
-export const computeBundleId = (
+export const computeDeploymentId = (
   actionRoot: string,
   targetRoot: string,
   numActions: number,
@@ -1133,18 +1133,18 @@ export const getPreviousCanonicalConfig = async (
 
   const latestProposalEvent = (
     await ChugSplashManager.queryFilter(
-      ChugSplashManager.filters.ChugSplashBundleProposed(
-        latestExecutionEvent.args.bundleId
+      ChugSplashManager.filters.ChugSplashDeploymentProposed(
+        latestExecutionEvent.args.deploymentId
       )
     )
   ).at(-1)
 
   if (latestProposalEvent === undefined) {
     throw new Error(
-      `ChugSplashManager emitted a ChugSplashActionExecuted event but not a ChugSplashBundleProposed event`
+      `ChugSplashManager emitted a ChugSplashActionExecuted event but not a ChugSplashDeploymentProposed event`
     )
   } else if (latestProposalEvent.args === undefined) {
-    throw new Error(`ChugSplashBundleProposed event does not have args`)
+    throw new Error(`ChugSplashDeploymentProposed event does not have args`)
   }
 
   if (remoteExecution) {
@@ -1235,23 +1235,23 @@ export const getConfigArtifactsRemote = async (
 
 export const getDeploymentEvents = async (
   ChugSplashManager: ethers.Contract,
-  bundleId: string
+  deploymentId: string
 ): Promise<ethers.Event[]> => {
   const [approvalEvent] = await ChugSplashManager.queryFilter(
-    ChugSplashManager.filters.ChugSplashBundleApproved(bundleId)
+    ChugSplashManager.filters.ChugSplashDeploymentApproved(deploymentId)
   )
   const [completedEvent] = await ChugSplashManager.queryFilter(
-    ChugSplashManager.filters.ChugSplashBundleCompleted(bundleId)
+    ChugSplashManager.filters.ChugSplashDeploymentCompleted(deploymentId)
   )
 
   const proxyDeployedEvents = await ChugSplashManager.queryFilter(
-    ChugSplashManager.filters.DefaultProxyDeployed(null, null, bundleId),
+    ChugSplashManager.filters.DefaultProxyDeployed(null, null, deploymentId),
     approvalEvent.blockNumber,
     completedEvent.blockNumber
   )
 
   const contractDeployedEvents = await ChugSplashManager.queryFilter(
-    ChugSplashManager.filters.ContractDeployed(null, null, bundleId),
+    ChugSplashManager.filters.ContractDeployed(null, null, deploymentId),
     approvalEvent.blockNumber,
     completedEvent.blockNumber
   )

--- a/packages/executor/src/gql/index.ts
+++ b/packages/executor/src/gql/index.ts
@@ -4,7 +4,7 @@ const updateDeploymentMutation = gql`
   mutation UpdateDeployment($input: UpdateDeploymentInput!) {
     UpdateDeployment(input: $input) {
       id
-      bundleId
+      deploymentId
     }
   }
 `
@@ -31,14 +31,14 @@ type Contract = {
 
 export const updateDeployment = async (
   client: GraphQLClient,
-  bundleId: string,
+  deploymentId: string,
   status: DeploymentStatus,
   contracts: Contract[]
 ) => {
   if (contracts.length > 0) {
     await client.request(createContractsMutation, {
       input: {
-        bundleId,
+        deploymentId,
         contracts,
         publicKey: process.env.MANAGED_PUBLIC_KEY,
       },
@@ -47,7 +47,7 @@ export const updateDeployment = async (
 
   await client.request(updateDeploymentMutation, {
     input: {
-      bundleId,
+      deploymentId,
       status,
       publicKey: process.env.MANAGED_PUBLIC_KEY,
     },

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -106,9 +106,9 @@ export class ChugSplashExecutor extends BaseServiceV2<
       level: options.logLevel,
     })
 
-    // This represents a queue of "BundleApproved" events to execute.
+    // This represents a queue of "DeploymentApproved" events to execute.
     this.state.eventsQueue = []
-    // This represents a cache of "BundleApproved" events which are currently being executed.
+    // This represents a cache of "DeploymentApproved" events which are currently being executed.
     this.state.executionCache = []
 
     const keyStrings = options.privateKeys.split(',')
@@ -166,7 +166,7 @@ export class ChugSplashExecutor extends BaseServiceV2<
 
     // Get approval events in blocks after the stored block number
     const newApprovalEvents = await registry.queryFilter(
-      registry.filters.EventAnnounced('ChugSplashBundleApproved'),
+      registry.filters.EventAnnounced('ChugSplashDeploymentApproved'),
       this.state.lastBlockNumber,
       latestBlockNumber
     )
@@ -204,7 +204,7 @@ export class ChugSplashExecutor extends BaseServiceV2<
     // execution, and we only want to attempt to execute each element once.
     const eventsCopy = this.state.eventsQueue.slice()
 
-    // execute all approved bundles
+    // execute all approved deployments
     for (const executorEvent of eventsCopy) {
       this.logger.info('[ChugSplash]: detected a project...')
 

--- a/specs/chugsplash-manager.md
+++ b/specs/chugsplash-manager.md
@@ -1,6 +1,6 @@
 # ChugSplashManager Speed Spec
 
-## Bundle states
+## Deployment states
 
 ```typescript
 enum ActionType {
@@ -10,7 +10,7 @@ enum ActionType {
 ```
 
 ```typescript
-enum BundleStatus {
+enum DeploymentStatus {
   EMPTY,
   PROPOSED,
   APPROVED,
@@ -20,8 +20,8 @@ enum BundleStatus {
 ```
 
 ```typescript
-struct BundleState {
-  BundleStatus status;
+struct DeploymentState {
+  DeploymentStatus status;
   bool[] executions;
   uint256 actionsExecuted;
   uint256 timeClaimed;
@@ -37,10 +37,10 @@ struct Action {
 }
 ```
 
-## Computing a unique bundle ID
+## Computing a unique deployment ID
 
 ```typescript
-const computeBundleId = (
+const computeDeploymentId = (
   bundleRoot: bytes32,
   bundleSize: uint256,
   configUri: string
@@ -59,9 +59,9 @@ const computeBundleId = (
 
 ```typescript
 const getSelectedExecutor = (
-  bundleId: bytes32
+  deploymentId: bytes32
 ): address => {
-  return bundles[bundleId].selectedExecutor
+  return bundles[deploymentId].selectedExecutor
 }
 ```
 
@@ -83,24 +83,24 @@ const getProxyByName = (
 
 * A ChugSplash bundle MUST only be proposable by the `admin` of the `ChugSplashManager`.
 * Bundles MUST be in the `EMPTY` state before they can be proposed.
-* Proposing a bundle puts the bundle in the `PROPOSED` state.
-* The ChugSplashManager MUST emit the event ChugSplashBundleProposed with the ID of the bundle, the bundle root, the bundle size, and the config URI as parameters. The ChugSplashManager MUST announce this event to the registry.
+* Proposing a bundle puts the deployment in the `PROPOSED` state.
+* The ChugSplashManager MUST emit the event ChugSplashDeploymentProposed with the ID of the deployment, the bundle root, the deployment size, and the config URI as parameters. The ChugSplashManager MUST announce this event to the registry.
 
 ## Approving a ChugSplash bundle
 
 * A ChugSplash bundle MUST only be approvable by the `admin` of the `ChugSplashManager`.
 * Bundles MUST have be in the `PROPOSED` state before they can be approved.
 * There MUST NOT be any active bundle.
-* Approving a bundle MUST put the bundle in the `APPROVED` state.
-* Approving a bundle MUST make the approved bundle the active bundle.
+* Approving a bundle MUST put the deployment in the `APPROVED` state.
+* Approving a bundle MUST make the approved deployment the active bundle.
 * The balance of the ChugSplashManager minus the current `totalDebt` MUST be greater than or equal to OWNER_BOND_AMOUNT ETH in its balance.
-* The ChugSplashManager MUST emit the event ChugSplashBundleApproved with the ID of the bundle as the only parameter. The ChugSplashManager MUST announce this event to the registry.
+* The ChugSplashManager MUST emit the event ChugSplashDeploymentApproved with the ID of the deployment as the only parameter. The ChugSplashManager MUST announce this event to the registry.
 
 ## Executing a ChugSplash action
-* There MUST be an `activeBundleId` to execute a ChugSplash action.
+* There MUST be an `activeDeploymentId` to execute a ChugSplash action.
 * The `_actionIndex` MUST NOT already have been executed.
 * A ChugSplash action MUST be executed by the `selectedExecutor`.
-* The `_action`, `activeBundleId`, `_actionIndex`, and `_proof` MUST produce a valid Merkle proof.
+* The `_action`, `activeDeploymentId`, `_actionIndex`, and `_proof` MUST produce a valid Merkle proof.
 * If the proxy corresponding to the `target` has not already been deployed:
   * The proxy MUST be deployed using Create2.
   * The proxy MUST have the same address as the the address returned by a call to `getProxyByTargetName`.
@@ -113,40 +113,40 @@ const getProxyByName = (
 * Otherwise, if the current action is `DEPLOY_IMPLEMENTATION`:
   * A call to `_deployImplementation` MUST be executed with `proxy`, `contractKind`, and `data` as arguments.
 * Otherwise, the current call MUST revert.
-* The ChugSplashManager MUST emit the event ChugSplashActionExecuted with the active bundle ID, the executor's address, and the action index.
+* The ChugSplashManager MUST emit the event ChugSplashActionExecuted with the active deployment ID, the executor's address, and the action index.
 * The ChugSplashManager MUST announce this event to the registry.
 * Executing an action MUST increase the `totalDebt` and the current executor's `debt` by `block.basefee * gasUsed * (100 + executorPaymentPercentage) / 100)`, where `gasUsed` is calculated using `gasleft()` plus the intrinsic gas (21k) plus the calldata usage.
 
 ## Completing a ChugSplash bundle
-* There MUST be an `activeBundleId`.
+* There MUST be an `activeDeploymentId`.
 * The actions MUST be executed by the `selectedExecutor`.
 * For each `_action` in `_actions`:
   * The `_actionIndex` MUST NOT already have been executed.
-  * The `_action`, `activeBundleId`, `_actionIndex`, and `_proof` MUST produce a valid Merkle proof.
+  * The `_action`, `activeDeploymentId`, `_actionIndex`, and `_proof` MUST produce a valid Merkle proof.
   * The `actionsExecuted` MUST be incremented by one.
   * The current `_actionIndex` MUST be set to `true`.
   * A call to `_upgradeProxyTo` MUST be executed with the corresponding `proxy`, `adapter`, and `implementation` as arguments.
   * The ChugSplashManager MUST increase the current executor's `debt` and the `totalDebt` by `block.basefee * gasUsed * (100 + executorPaymentPercentage) / 100)`, where `gasUsed` is calculated using `gasleft()` plus the intrinsic gas (21k) plus the calldata usage.
-  * The ChugSplashManager MUST emit the event ChugSplashActionExecuted with the active bundle ID, the executor's address, and the action index.
+  * The ChugSplashManager MUST emit the event ChugSplashActionExecuted with the active deployment ID, the executor's address, and the action index.
   * The ChugSplashManager MUST announce this event to the registry.
-* The call MUST revert if all of the actions in the bundle were not executed.
-* The bundle status MUST be set to `COMPLETED`.
-* The `activeBundleId` MUST be set to `bytes32(0)`.
+* The call MUST revert if all of the actions in the deployment were not executed.
+* The deployment status MUST be set to `COMPLETED`.
+* The `activeDeploymentId` MUST be set to `bytes32(0)`.
 * The ChugSplashManager MUST increase the `debt` owed to the current executor by the `EXECUTOR_BOND_AMOUNT`.
-* The ChugSplashManager MUST emit the event ChugSplashBundleCompleted with the active bundle ID, the executor's address, and the action index.
+* The ChugSplashManager MUST emit the event ChugSplashDeploymentCompleted with the active deployment ID, the executor's address, and the action index.
 * The ChugSplashManager MUST announce this event to the registry.
 
 ## Cancelling a ChugSplash bundle
 
 * A ChugSplash bundle MUST only be cancellable by the `admin` of the `ChugSplashManager`.
 * Bundles MUST be in the `APPROVED` state before they can be cancelled.
-* Cancelling a bundle MUST put the bundle in the `CANCELLED` state.
+* Cancelling a bundle MUST put the deployment in the `CANCELLED` state.
 * Cancelling a bundle MUST remove the active bundle.
 * If an executor has been selected within the last `EXECUTION_LOCK_TIME` seconds (i.e. `block.timestamp` <= `timeClaimed + EXECUTION_LOCK_TIME`):
   * The ChugSplashManager MUST increase the `debt` owed to the current executor by `OWNER_BOND_AMOUNT + EXECUTOR_BOND_AMOUNT`.
   * The ChugSplashManager MUST increase the `totalDebt` by the `OWNER_BOND_AMOUNT`.
 * Otherwise, the `totalDebt` must decrease by the `EXECUTOR_BOND_AMOUNT`.
-* The ChugSplashManager MUST emit the event ChugSplashBundleCancelled with the ID of the bundle and the total number of actions executed. The ChugSplashManager MUST announce this event to the registry.
+* The ChugSplashManager MUST emit the event ChugSplashBundleCancelled with the ID of the deployment and the total number of actions executed. The ChugSplashManager MUST announce this event to the registry.
 
 ## Withdrawing ETH
 
@@ -173,14 +173,14 @@ const getProxyByName = (
 * The bundle being claimed MUST have an `APPROVED` status.
 * The current `block.timestamp` MUST be greater than the `timeClaimed` plus the `EXECUTION_LOCK_TIME`.
 * Claiming a bundle MUST set the `timeClaimed` to be the `block.timestamp`.
-* Claiming a bundle MUST set the `selectedExecutor` to be the executor that claimed the bundle.
+* Claiming a bundle MUST set the `selectedExecutor` to be the executor that claimed the deployment.
 * If there was no previously selected executor for this bundle:
   * The ChugSplashManager MUST increase the `totalDebt` by the `EXECUTOR_BOND_AMOUNT`.
-* The ChugSplashManager MUST emit the event ChugSplashBundleClaimed with the claimed bundle ID and the address of the executor. The ChugSplashManager MUST announce this event to the registry.
+* The ChugSplashManager MUST emit the event ChugSplashBundleClaimed with the claimed deployment ID and the address of the executor. The ChugSplashManager MUST announce this event to the registry.
 
 ## Transferring proxy ownership from the ChugSplashManager
 
 * The `admin` of the `ChugSplashManager` MUST be the only address that can transfer proxy ownership from the ChugSplashManager.
-* There MUST NOT be an active bundle ID.
+* There MUST NOT be an active deployment ID.
 * The delegatecall to transfer proxy ownership MUST succeed.
 * The ChugSplashManager MUST emit the ProxyOwnershipTransferred event with the name of the target corresponding to the proxy (indexed and unindexed), the address of the proxy, and the new owner of the proxy. The ChugSplashManager MUST announce this event to the registry.


### PR DESCRIPTION
Throughout our codebase, the term "bundle" currently describes two things:
1. A static data type that contains the Merkle root, its leafs, and proofs. I.e. the action bundle and the target bundle.
2. A deployment/upgrade. I.e. the bundle state, bundle status, bundle ID.

Using "bundle" as a catch-all term was more acceptable when a deployment/upgrade was basically just a single bundle. (See [here](https://github.com/chugsplash/chugsplash/blob/3a7b19cd4b6ec5556dc48d3a9f7b25de983ea713/packages/contracts/contracts/ChugSplashManager.sol#L156) for a very early version of the propose function). However, now that we use two bundles, it makes more sense to call it a "bundles ID", "bundles state", etc, but that's grammatically awkward.

In this PR, I changed all instances of case 2 to "deployment" instead of "bundle". In other words, it's now a deployment ID, deployment state, and deployment status. Case 1 remains the same, so action bundles and target bundles keep the same names.

This solution isn't perfect, since now "deployments" refer to upgrades too, which are distinct in smart contract land. We could call it an "update" instead, but I'm personally fine with this solution