### PR TITLE
fix(ct): deploy contracts before modifying proxies during execution

### DIFF
--- a/.changeset/eight-eggs-cover.md
+++ b/.changeset/eight-eggs-cover.md
@@ -1,0 +1,7 @@
+---
+'@chugsplash/contracts': minor
+'@chugsplash/executor': minor
+'@chugsplash/core': minor
+---
+
+Deploy contracts before modifying proxies during execution

--- a/docs/how-chugsplash-works.md
+++ b/docs/how-chugsplash-works.md
@@ -137,9 +137,9 @@ As soon as the `approve` transaction is submitted, the deployment can be execute
 Once the executor notices an approval event, it must be able to re-create the Merkle tree in order to execute the deployment. It does this by retrieving the IPFS URI that was submitted on-chain as part of the `propose` transaction. It uses the URI to fetch the ChugSplash config file and the compiler inputs from IPFS. Then, it uses these two sources to re-create the Merkle tree.
 
 The deployment is executed in three phases, which must occur in order:
-1. `initiateExecution`: Each proxy's implementation is set `address(0)` in a single transaction at the very beginning. This step is only necessary for contracts that are being upgraded.
+1. `initiateUpgrade`: Each proxy's implementation is set `address(0)` in a single transaction at the very beginning. This step is only necessary for contracts that are being upgraded.
 2. `executeAction`: The deployment is executed using the `SetStorage` and `DeployImplementation` actions. This can consist of many transactions for a larger deployment.
-3. `completeExecution`: Each proxy is upgraded to its new implementation in a single transaction at the very end.
+3. `finalizeUpgrade`: Each proxy is upgraded to its new implementation in a single transaction at the very end.
 
 Each of these functions exists on the `ChugSplashManager`. If the executor attempts to send a transaction that isn't in the correct order, the call will revert.
 

--- a/packages/contracts/.solhint.json
+++ b/packages/contracts/.solhint.json
@@ -4,7 +4,7 @@
   "rules": {
     "prettier/prettier": "error",
     "compiler-version": "off",
-    "code-complexity": ["warn", 5],
+    "code-complexity": "off",
     "max-line-length": ["error", 100],
     "func-param-name-mixedcase": "error",
     "func-name-mixedcase": "off",

--- a/packages/contracts/contracts/ChugSplashDataTypes.sol
+++ b/packages/contracts/contracts/ChugSplashDataTypes.sol
@@ -10,6 +10,7 @@ pragma solidity ^0.8.15;
  * @custom:field targets The number of targets in the deployment.
  * @custom:field actionRoot The root of the Merkle tree of actions.
  * @custom:field targetRoot The root of the Merkle tree of targets.
+ * @custom:field numNonProxyContracts The number of non-proxy contracts in the deployment.
  * @custom:field actionsExecuted The number of actions that have been executed so far in the
    deployment.
  * @custom:field timeClaimed The time at which the deployment was claimed by a remote executor.
@@ -22,6 +23,7 @@ struct DeploymentState {
     uint256 targets;
     bytes32 actionRoot;
     bytes32 targetRoot;
+    uint256 numNonProxyContracts;
     uint256 actionsExecuted;
     uint256 timeClaimed;
     address selectedExecutor;
@@ -81,15 +83,17 @@ enum ChugSplashActionType {
  * @custom:value EMPTY The deployment does not exist.
  * @custom:value PROPOSED The deployment has been proposed.
  * @custom:value APPROVED The deployment has been approved by the owner.
- * @custom:value INITIATED The deployment has been initiated.
+ * @custom:value PROXIES_INITIATED The proxies in the deployment have been initiated.
  * @custom:value COMPLETED The deployment has been completed.
  * @custom:value CANCELLED The deployment has been cancelled.
+ * @custom:value FAILED The deployment has failed.
  */
 enum DeploymentStatus {
     EMPTY,
     PROPOSED,
     APPROVED,
-    INITIATED,
+    PROXIES_INITIATED,
     COMPLETED,
-    CANCELLED
+    CANCELLED,
+    FAILED
 }

--- a/packages/contracts/contracts/adapters/DefaultAdapter.sol
+++ b/packages/contracts/contracts/adapters/DefaultAdapter.sol
@@ -27,14 +27,14 @@ contract DefaultAdapter is IProxyAdapter {
     /**
      * @inheritdoc IProxyAdapter
      */
-    function initiateExecution(address payable _proxy) external {
+    function initiateUpgrade(address payable _proxy) external {
         Proxy(_proxy).upgradeTo(proxyUpdater);
     }
 
     /**
      * @inheritdoc IProxyAdapter
      */
-    function completeExecution(address payable _proxy, address _implementation) external {
+    function finalizeUpgrade(address payable _proxy, address _implementation) external {
         Proxy(_proxy).upgradeTo(_implementation);
     }
 

--- a/packages/contracts/contracts/adapters/OZTransparentAdapter.sol
+++ b/packages/contracts/contracts/adapters/OZTransparentAdapter.sol
@@ -27,14 +27,14 @@ contract OZTransparentAdapter is IProxyAdapter {
     /**
      * @inheritdoc IProxyAdapter
      */
-    function initiateExecution(address payable _proxy) external {
+    function initiateUpgrade(address payable _proxy) external {
         Proxy(_proxy).upgradeTo(proxyUpdater);
     }
 
     /**
      * @inheritdoc IProxyAdapter
      */
-    function completeExecution(address payable _proxy, address _implementation) external {
+    function finalizeUpgrade(address payable _proxy, address _implementation) external {
         Proxy(_proxy).upgradeTo(_implementation);
     }
 

--- a/packages/contracts/contracts/adapters/OZUUPSBaseAdapter.sol
+++ b/packages/contracts/contracts/adapters/OZUUPSBaseAdapter.sol
@@ -29,7 +29,7 @@ abstract contract OZUUPSBaseAdapter is IProxyAdapter {
     /**
      * @inheritdoc IProxyAdapter
      */
-    function initiateExecution(address payable _proxy) external {
+    function initiateUpgrade(address payable _proxy) external {
         OZUUPSUpdater(_proxy).upgradeTo(proxyUpdater);
         OZUUPSUpdater(_proxy).initiate();
     }
@@ -37,7 +37,7 @@ abstract contract OZUUPSBaseAdapter is IProxyAdapter {
     /**
      * @inheritdoc IProxyAdapter
      */
-    function completeExecution(address payable _proxy, address _implementation) external {
+    function finalizeUpgrade(address payable _proxy, address _implementation) external {
         OZUUPSUpdater(_proxy).complete(_implementation);
     }
 

--- a/packages/contracts/contracts/interfaces/IProxyAdapter.sol
+++ b/packages/contracts/contracts/interfaces/IProxyAdapter.sol
@@ -13,7 +13,7 @@ interface IProxyAdapter {
      *
      * @param _proxy Address of the proxy.
      */
-    function initiateExecution(address payable _proxy) external;
+    function initiateUpgrade(address payable _proxy) external;
 
     /**
      * @notice Complete a deployment or upgrade of a proxy.
@@ -21,7 +21,7 @@ interface IProxyAdapter {
      * @param _proxy          Address of the proxy.
      * @param _implementation Address of the proxy's final implementation.
      */
-    function completeExecution(address payable _proxy, address _implementation) external;
+    function finalizeUpgrade(address payable _proxy, address _implementation) external;
 
     /**
      * @notice Sets a proxy's storage slot value at a given storage slot key and offset.

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -10,7 +10,7 @@ const config: HardhatUserConfig = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 100,
+        runs: 1000,
       },
       outputSelection: {
         '*': {

--- a/packages/core/src/actions/bundle.ts
+++ b/packages/core/src/actions/bundle.ts
@@ -62,6 +62,14 @@ export const isDeployContractAction = (
   return (action as DeployContractAction).code !== undefined
 }
 
+export const getDeployContractActions = (
+  actionBundle: ChugSplashActionBundle
+): Array<DeployContractAction> => {
+  return actionBundle.actions
+    .map((action) => fromRawChugSplashAction(action.action))
+    .filter(isDeployContractAction)
+}
+
 /**
  * Converts the "nice" action structs into a "raw" action struct (better for Solidity but
  * worse for users here).

--- a/packages/core/src/actions/types.ts
+++ b/packages/core/src/actions/types.ts
@@ -15,9 +15,10 @@ export enum DeploymentStatus {
   EMPTY,
   PROPOSED,
   APPROVED,
-  INITIATED,
+  PROXIES_INITIATED,
   COMPLETED,
   CANCELLED,
+  FAILED,
 }
 
 /**
@@ -114,6 +115,7 @@ export type DeploymentState = {
   actions: boolean[]
   actionRoot: string
   targetRoot: string
+  numNonProxyContracts: number
   targets: number
   actionsExecuted: BigNumber
   timeClaimed: BigNumber

--- a/packages/core/src/config/fetch.ts
+++ b/packages/core/src/config/fetch.ts
@@ -5,6 +5,7 @@ import { ChugSplashBundles } from '../actions/types'
 import { bundleRemoteSubtask } from '../languages/solidity/compiler'
 import { callWithTimeout, computeDeploymentId } from '../utils'
 import { CanonicalChugSplashConfig } from './types'
+import { getDeployContractActions } from '../actions/bundle'
 
 export const chugsplashFetchSubtask = async (args: {
   configUri: string
@@ -74,6 +75,7 @@ export const verifyDeployment = async (
       targetBundle.root,
       actionBundle.actions.length,
       targetBundle.targets.length,
+      getDeployContractActions(actionBundle).length,
       configUri
     )
   ) {

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -76,7 +76,7 @@ export const monitorExecution = async (
   spinner.succeed('Execution initiated.')
 
   const totalNumActions = bundles.actionBundle.actions.length
-  while (deploymentState.status === DeploymentStatus.INITIATED) {
+  while (deploymentState.status === DeploymentStatus.PROXIES_INITIATED) {
     if (deploymentState.actionsExecuted.toNumber() === totalNumActions) {
       spinner.start(`All actions have been executed. Completing execution...`)
     } else {

--- a/packages/executor/chugsplash/ExecutorTest.config.ts
+++ b/packages/executor/chugsplash/ExecutorTest.config.ts
@@ -8,13 +8,21 @@ const config: UserChugSplashConfig = {
     claimer: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   },
   contracts: {
-    ExecutorTest: {
-      contract: 'ExecutorTest',
+    ExecutorProxyTest: {
+      contract: 'ExecutorProxyTest',
       variables: {
         number: 1,
         stored: true,
         storageName: 'First',
         otherStorage: '0x1111111111111111111111111111111111111111',
+      },
+    },
+    ExecutorNonProxyTest: {
+      contract: 'ExecutorNonProxyTest',
+      kind: 'no-proxy',
+      unsafeAllowFlexibleConstructor: true,
+      constructorArgs: {
+        _val: 1,
       },
     },
   },

--- a/packages/executor/contracts/ExecutorTest.sol
+++ b/packages/executor/contracts/ExecutorTest.sol
@@ -1,9 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-contract ExecutorTest {
+contract ExecutorProxyTest {
     uint8 public number;
     bool public stored;
     address public otherStorage;
     string public storageName;
+}
+
+contract ExecutorNonProxyTest {
+    uint8 public val;
+
+    constructor(uint8 _val) {
+        val = _val;
+    }
 }

--- a/packages/executor/test/Executor.test.ts
+++ b/packages/executor/test/Executor.test.ts
@@ -19,8 +19,9 @@ import { createChugSplashRuntime } from '../../plugins/src/utils'
 const configPath = './chugsplash/ExecutorTest.config.ts'
 
 describe('Remote Execution', () => {
-  let ExecutorTest: Contract
-  beforeEach(async () => {
+  let Proxy: Contract
+  let NonProxy: Contract
+  before(async () => {
     const provider = hre.ethers.provider
     const signer = provider.getSigner()
     const signerAddress = await signer.getAddress()
@@ -103,18 +104,27 @@ describe('Remote Execution', () => {
       cre
     )
 
-    ExecutorTest = await chugsplash.getContract(
+    Proxy = await chugsplash.getContract(
       parsedConfig.options.projectName,
-      'ExecutorTest'
+      'ExecutorProxyTest'
+    )
+
+    NonProxy = await chugsplash.getContract(
+      parsedConfig.options.projectName,
+      'ExecutorNonProxyTest'
     )
   })
 
-  it('does deploy remotely', async () => {
-    expect(await ExecutorTest.number()).to.equal(1)
-    expect(await ExecutorTest.stored()).to.equal(true)
-    expect(await ExecutorTest.storageName()).to.equal('First')
-    expect(await ExecutorTest.otherStorage()).to.equal(
+  it('does deploy proxied contract remotely', async () => {
+    expect(await Proxy.number()).to.equal(1)
+    expect(await Proxy.stored()).to.equal(true)
+    expect(await Proxy.storageName()).to.equal('First')
+    expect(await Proxy.otherStorage()).to.equal(
       '0x1111111111111111111111111111111111111111'
     )
+  })
+
+  it('does deploy non-proxy contract remotely', async () => {
+    expect(await NonProxy.val()).equals(1)
   })
 })

--- a/packages/plugins/chugsplash/VariableValidation.config.ts
+++ b/packages/plugins/chugsplash/VariableValidation.config.ts
@@ -78,6 +78,16 @@ const config: UserChugSplashConfig = {
         hello: 'world',
       },
     },
+    Reverter1: {
+      contract: 'Reverter',
+      kind: 'no-proxy',
+      unsafeAllowFlexibleConstructor: true,
+    },
+    Reverter2: {
+      contract: 'Reverter',
+      kind: 'no-proxy',
+      unsafeAllowFlexibleConstructor: true,
+    },
   },
 }
 

--- a/packages/plugins/contracts/Reverter.sol
+++ b/packages/plugins/contracts/Reverter.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+contract Reverter {
+    constructor() {
+        revert("Reverter: revert");
+    }
+}

--- a/packages/plugins/test/Validation.spec.ts
+++ b/packages/plugins/test/Validation.spec.ts
@@ -416,4 +416,16 @@ describe('Validate', () => {
       `Missing member(s) in struct _structMissingMembers: b`
     )
   })
+
+  it('did catch non-proxy contract constructor reverting', async () => {
+    expect(validationOutput).to.have.string(
+      `The following constructors will revert:`
+    )
+    expect(validationOutput).to.have.string(
+      `- Reverter1. Reason: 'Reverter: revert'`
+    )
+    expect(validationOutput).to.have.string(
+      `- Reverter2. Reason: 'Reverter: revert'`
+    )
+  })
 })

--- a/specs/chugsplash-manager.md
+++ b/specs/chugsplash-manager.md
@@ -113,7 +113,7 @@ const getProxyByName = (
 * Otherwise, if the current action is `DEPLOY_IMPLEMENTATION`:
   * A call to `_deployImplementation` MUST be executed with `proxy`, `contractKind`, and `data` as arguments.
 * Otherwise, the current call MUST revert.
-* The ChugSplashManager MUST emit the event ChugSplashActionExecuted with the active deployment ID, the executor's address, and the action index.
+* The ChugSplashManager MUST emit the event SetProxyStorage with the active deployment ID, the executor's address, and the action index.
 * The ChugSplashManager MUST announce this event to the registry.
 * Executing an action MUST increase the `totalDebt` and the current executor's `debt` by `block.basefee * gasUsed * (100 + executorPaymentPercentage) / 100)`, where `gasUsed` is calculated using `gasleft()` plus the intrinsic gas (21k) plus the calldata usage.
 
@@ -127,7 +127,7 @@ const getProxyByName = (
   * The current `_actionIndex` MUST be set to `true`.
   * A call to `_upgradeProxyTo` MUST be executed with the corresponding `proxy`, `adapter`, and `implementation` as arguments.
   * The ChugSplashManager MUST increase the current executor's `debt` and the `totalDebt` by `block.basefee * gasUsed * (100 + executorPaymentPercentage) / 100)`, where `gasUsed` is calculated using `gasleft()` plus the intrinsic gas (21k) plus the calldata usage.
-  * The ChugSplashManager MUST emit the event ChugSplashActionExecuted with the active deployment ID, the executor's address, and the action index.
+  * The ChugSplashManager MUST emit the event SetProxyStorage with the active deployment ID, the executor's address, and the action index.
   * The ChugSplashManager MUST announce this event to the registry.
 * The call MUST revert if all of the actions in the deployment were not executed.
 * The deployment status MUST be set to `COMPLETED`.


### PR DESCRIPTION
This PR also:
* Replaces revert strings with custom errors in the ChugSplashManager. This allows the contract to fit comfortably under the max contract size limit.
* Adds parsing logic that checks if any constructors revert via `estimateGas`. It displays the constructor error messages to the user for each contract in the config that would revert if deployed.
* Adds logic to the remote executor that checks if any constructors revert, again using `estimateGas`. This occurs before the executor attempts to claim the bundle. If a constructor in the config reverts, the executor calls `logger.error` and discards the execution event. (This logic is why there's no unit test for the remote executor when it handles a constructor reverting on-chain. It'd be challenging to come up with a unit test that passes this check and reverts on-chain.)