### PR TITLE
feat(core): Support gasless proposals with meta transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
       "@chugsplash/{contracts,plugins}/@openzeppelin/contracts-upgradeable",
       "@chugsplash/{contracts,plugins}/@eth-optimism/contracts-bedrock",
       "@chugsplash/{contracts,plugins}/@eth-optimism/contracts",
-      "@chugsplash/plugins/@chugsplash/contracts"
+      "@chugsplash/plugins/@chugsplash/contracts",
+      "@chugsplash/contracts/@thirdweb-dev/contracts"
     ]
   },
   "scripts": {

--- a/packages/contracts/contracts/Import.sol
+++ b/packages/contracts/contracts/Import.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import { Forwarder } from "@thirdweb-dev/contracts/forwarder/Forwarder.sol";

--- a/packages/contracts/contracts/ManagedService.sol
+++ b/packages/contracts/contracts/ManagedService.sol
@@ -12,7 +12,26 @@ Users can opt in to this functionality if they choose to do so.
 contract ManagedService is AccessControl {
     bytes32 public constant CALLER_ROLE = keccak256("CALLER_ROLE");
 
+    /**
+     * @notice Role required to collect the protocol creator's payment.
+     */
+    bytes32 internal constant PROTOCOL_PAYMENT_RECIPIENT_ROLE =
+        keccak256("PROTOCOL_PAYMENT_RECIPIENT_ROLE");
+
     event ExecutedCall(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @notice Emitted when a protocol payment recipient claims a payment.
+     *
+     * @param recipient The recipient that withdrew the funds.
+     * @param amount    Amount of ETH withdrawn.
+     */
+    event ProtocolPaymentClaimed(address indexed recipient, uint256 amount);
+
+    /**
+     * @notice Reverts if the caller is not a protocol payment recipient.
+     */
+    error CallerIsNotProtocolPaymentRecipient();
 
     /**
      * @param _owner The address that will be granted the `DEFAULT_ADMIN_ROLE`. This address is the
@@ -36,5 +55,26 @@ contract ManagedService is AccessControl {
         (bool success, bytes memory returnData) = _to.call{ value: msg.value }(_data);
         require(success, "PermissionedCaller: call failed");
         return returnData;
+    }
+
+    /**
+     * @notice Allows the protocol creators to claim their royalty, which is only earned during
+       remotely executed deployments.
+     */
+    function claimProtocolPayment(uint256 _amount) external {
+        if (!hasRole(PROTOCOL_PAYMENT_RECIPIENT_ROLE, msg.sender)) {
+            revert CallerIsNotProtocolPaymentRecipient();
+        }
+        if (_amount > address(this).balance) {
+            revert("ManagedService: Insufficient funds to withdraw protocol payment");
+        }
+
+        emit ProtocolPaymentClaimed(msg.sender, _amount);
+
+        // slither-disable-next-line arbitrary-send-eth
+        (bool success, ) = payable(msg.sender).call{ value: _amount }(new bytes(0));
+        if (!success) {
+            revert("ManagedService: Failed to withdraw protocol payment");
+        }
     }
 }

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -7,9 +7,10 @@ remappings = [
   '@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/',
   '@eth-optimism/contracts-bedrock/=node_modules/@eth-optimism/contracts-bedrock',
   '@eth-optimism/contracts/=node_modules/@eth-optimism/contracts',
+  '@thirdweb-dev/contracts/=node_modules/@thirdweb-dev/contracts',
+  '@connext/interfaces=node_modules/@connext/interfaces/',
   'forge-std/=node_modules/forge-std/src/',
-  'ds-test/=node_modules/ds-test/src/',
-  '@connext/interfaces=node_modules/@connext/interfaces/'
+  'ds-test/=node_modules/ds-test/src/'
 ]
 
 gas_price=1

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -10,7 +10,7 @@ const config: HardhatUserConfig = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 1000,
+        runs: 100,
       },
       outputSelection: {
         '*': {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -43,7 +43,8 @@
     "forge-std": "https://github.com/foundry-rs/forge-std#2a2ce3692b8c1523b29de3ec9d961ee9fbbc43a6",
     "hardhat": "^2.9.9",
     "solhint": "^3.4.1",
-    "solhint-plugin-prettier": "^0.0.5"
+    "solhint-plugin-prettier": "^0.0.5",
+    "@thirdweb-dev/contracts": "^3.5.1"
   },
   "dependencies": {
     "@eth-optimism/contracts": "^0.5.40",

--- a/packages/contracts/src/constants.ts
+++ b/packages/contracts/src/constants.ts
@@ -9,6 +9,7 @@ import {
   OZUUPSAccessControlAdapterArtifact,
   DefaultGasPriceCalculatorArtifact,
   DefaultCreate2Artifact,
+  ForwarderArtifact,
 } from './ifaces'
 
 export const OWNER_MULTISIG_ADDRESS =
@@ -137,4 +138,10 @@ export const OZ_TRANSPARENT_ADAPTER_ADDRESS = ethers.utils.getCreate2Address(
       ),
     ]
   )
+)
+
+export const FORWARDER_ADDRESS = ethers.utils.getCreate2Address(
+  DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
+  ethers.constants.HashZero,
+  ethers.utils.solidityKeccak256(['bytes'], [ForwarderArtifact.bytecode])
 )

--- a/packages/contracts/src/ifaces.ts
+++ b/packages/contracts/src/ifaces.ts
@@ -15,6 +15,7 @@ export const OZUUPSAccessControlAdapterArtifact = require('../artifacts/contract
 export const OZTransparentAdapterArtifact = require('../artifacts/contracts/adapters/OZTransparentAdapter.sol/OZTransparentAdapter.json')
 export const DefaultGasPriceCalculatorArtifact = require('../artifacts/contracts/DefaultGasPriceCalculator.sol/DefaultGasPriceCalculator.json')
 export const DefaultCreate2Artifact = require('../artifacts/contracts/DefaultCreate2.sol/DefaultCreate2.json')
+export const ForwarderArtifact = require('../artifacts/@thirdweb-dev/contracts/forwarder/Forwarder.sol/Forwarder.json')
 
 const directoryPath = path.join(__dirname, '../artifacts/build-info')
 const fileNames = fs.readdirSync(directoryPath)
@@ -41,3 +42,4 @@ export const OZTransparentAdapterABI = OZTransparentAdapterArtifact.abi
 export const DefaultGasPriceCalculatorABI =
   DefaultGasPriceCalculatorArtifact.abi
 export const DefaultCreate2ABI = DefaultCreate2Artifact.abi
+export const ForwarderABI = ForwarderArtifact.abi

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "@eth-optimism/contracts-bedrock": "^0.8.0",
     "@eth-optimism/core-utils": "^0.9.1",
     "@ethersproject/abstract-provider": "^5.7.0",
+    "@metamask/eth-sig-util": "^5.1.0",
     "@nomiclabs/hardhat-etherscan": "^3.1.7",
     "@openzeppelin/hardhat-upgrades": "^1.22.1",
     "@openzeppelin/upgrades-core": "^1.20.6",
@@ -56,7 +57,7 @@
     "yesno": "^0.4.0"
   },
   "devDependencies": {
-    "hardhat": "^2.10.0",
-    "@nomiclabs/hardhat-ethers": "^2.2.1"
+    "@nomiclabs/hardhat-ethers": "^2.2.1",
+    "hardhat": "^2.10.0"
   }
 }

--- a/packages/core/src/addresses.ts
+++ b/packages/core/src/addresses.ts
@@ -22,6 +22,7 @@ import {
   OZTransparentAdapterArtifact,
   DefaultCreate2Artifact,
   DefaultGasPriceCalculatorArtifact,
+  FORWARDER_ADDRESS,
 } from '@chugsplash/contracts'
 import { constants, utils } from 'ethers'
 
@@ -89,6 +90,7 @@ export const getManagerConstructorValues = () => [
   EXECUTOR_PAYMENT_PERCENTAGE,
   PROTOCOL_PAYMENT_PERCENTAGE,
   Object.values(CURRENT_CHUGSPLASH_MANAGER_VERSION),
+  FORWARDER_ADDRESS,
 ]
 
 const [managerConstructorFragment] = ChugSplashManagerABI.filter(

--- a/packages/core/src/languages/solidity/predeploys.ts
+++ b/packages/core/src/languages/solidity/predeploys.ts
@@ -18,6 +18,8 @@ import {
   OZUUPSOwnableAdapterABI,
   OZUUPSAccessControlAdapterABI,
   OZTransparentAdapterABI,
+  ForwarderABI,
+  ForwarderArtifact,
   OZUUPSUpdaterArtifact,
   OZUUPSOwnableAdapterArtifact,
   OZUUPSAccessControlAdapterArtifact,
@@ -247,6 +249,20 @@ export const initializeChugSplash = async (
   )
 
   logger?.info('[ChugSplash]: deployed ChugSplashRegistry')
+
+  logger?.info('[ChugSplash]: deploying Forwarder...')
+
+  await doDeterministicDeploy(provider, {
+    signer: deployer,
+    contract: {
+      abi: ForwarderABI,
+      bytecode: ForwarderArtifact.bytecode,
+    },
+    args: [],
+    salt: ethers.constants.HashZero,
+  })
+
+  logger?.info('[ChugSplash]: deployed Forwarder')
 
   logger?.info('[ChugSplash]: deploying ChugSplashManager initial version...')
 

--- a/packages/core/src/metatxs.ts
+++ b/packages/core/src/metatxs.ts
@@ -1,0 +1,99 @@
+import { BigNumber, Contract, ethers } from 'ethers'
+import {
+  signTypedData,
+  SignTypedDataVersion,
+  TypedMessage,
+  MessageTypes,
+} from '@metamask/eth-sig-util'
+import { ForwarderABI, FORWARDER_ADDRESS } from '@chugsplash/contracts'
+
+const EIP712Domain = [
+  { name: 'name', type: 'string' },
+  { name: 'version', type: 'string' },
+  { name: 'chainId', type: 'uint256' },
+  { name: 'verifyingContract', type: 'address' },
+]
+
+type BaseForwardRequestType = {
+  from: string
+  to: string
+  data: string
+}
+
+type ForwardRequestType = BaseForwardRequestType & {
+  value: number
+  gas: number
+  nonce: number
+}
+
+const ForwardRequest = [
+  { name: 'from', type: 'address' },
+  { name: 'to', type: 'address' },
+  { name: 'value', type: 'uint256' },
+  { name: 'gas', type: 'uint256' },
+  { name: 'nonce', type: 'uint256' },
+  { name: 'data', type: 'bytes' },
+]
+
+export const getMetaTxTypeData = (
+  chainId: number,
+  verifyingContract: string
+) => {
+  return {
+    types: {
+      EIP712Domain,
+      ForwardRequest,
+    },
+    domain: {
+      name: 'GSNv2 Forwarder',
+      version: '0.0.1',
+      chainId,
+      verifyingContract,
+    },
+    primaryType: 'ForwardRequest',
+  }
+}
+
+export const signMessage = async (
+  key: string,
+  data: TypedMessage<MessageTypes>
+) => {
+  // If signer is a private key, use it to sign
+  const privateKey = Buffer.from(key.replace(/^0x/, ''), 'hex')
+  return signTypedData({
+    privateKey,
+    data,
+    version: SignTypedDataVersion.V4,
+  })
+}
+
+export const buildRequest = async (
+  forwarder: Contract,
+  input: BaseForwardRequestType
+): Promise<ForwardRequestType> => {
+  const nonce = await forwarder
+    .getNonce(input.from)
+    .then((n: BigNumber) => n.toString())
+  return { value: 0, gas: 1e6, nonce, ...input }
+}
+
+export const buildTypedData = async (
+  forwarder: Contract,
+  request: ForwardRequestType
+) => {
+  const chainId = await forwarder.provider.getNetwork().then((n) => n.chainId)
+  const typeData = getMetaTxTypeData(chainId, forwarder.address)
+  return { ...typeData, message: request }
+}
+
+export const signMetaTxRequest = async (
+  provider: ethers.providers.JsonRpcProvider,
+  privateKey: string,
+  input: BaseForwardRequestType
+) => {
+  const forwarder = new Contract(FORWARDER_ADDRESS, ForwarderABI, provider)
+  const request = await buildRequest(forwarder, input)
+  const toSign = await buildTypedData(forwarder, request)
+  const signature = await signMessage(privateKey, toSign)
+  return { signature, request }
+}

--- a/packages/plugins/.env.example
+++ b/packages/plugins/.env.example
@@ -1,0 +1,10 @@
+IPFS_PROJECT_ID=<ipfs project id to retrieve config file>
+IPFS_API_KEY_SECRET=<ipfs api key to retrieve config file>
+PRIVATE_KEY=<private key>
+DISABLE_ANALYTICS=true
+DEV_FILE_PATH=./dist/foundry/index.js
+NETWORK=localhost
+ALCHEMY_API_KEY=<Alchemy provider api key>
+CHUGSPLASH_INTERNAL__OWNER_PRIVATE_KEY=<Private key of the system owner (optional, defaults to the multisign)>
+CHUGSPLASH_API_KEY=<API key for the ChugSplash managed service>
+LOCAL_TEST_METATX_PROPOSE=<Used to allow meta transactions on local networks for testing purposes>

--- a/packages/plugins/chugsplash/Metatx.config.ts
+++ b/packages/plugins/chugsplash/Metatx.config.ts
@@ -1,0 +1,28 @@
+import { UserChugSplashConfig } from '@chugsplash/core'
+import { ethers } from 'ethers'
+
+const projectName = 'Meta txs'
+
+const config: UserChugSplashConfig = {
+  // Configuration options for the project:
+  options: {
+    organizationID: ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes(projectName)
+    ),
+    projectName,
+    claimer: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  },
+  contracts: {
+    Stateless: {
+      contract: 'Stateless',
+      kind: 'no-proxy',
+      constructorArgs: {
+        _immutableUint: 1,
+        _immutableContractReference:
+          '0x1111111111111111111111111111111111111111',
+      },
+    },
+  },
+}
+
+export default config

--- a/packages/plugins/test/Metatx.spec.ts
+++ b/packages/plugins/test/Metatx.spec.ts
@@ -1,0 +1,115 @@
+import * as path from 'path'
+
+import hre from 'hardhat'
+import { Contract } from 'ethers'
+import {
+  chugsplashClaimAbstractTask,
+  chugsplashProposeAbstractTask,
+  getChugSplashManager,
+  readUnvalidatedChugSplashConfig,
+  readValidatedChugSplashConfig,
+} from '@chugsplash/core'
+import { FORWARDER_ADDRESS, ForwarderArtifact } from '@chugsplash/contracts'
+import { expect } from 'chai'
+
+import { getArtifactPaths } from '../../plugins/dist'
+import { createChugSplashRuntime } from '../../plugins/src/utils'
+
+const configPath = './chugsplash/Metatx.config.ts'
+
+describe('Meta txs', () => {
+  process.env['LOCAL_TEST_METATX_PROPOSE'] = 'true'
+
+  let expectedDeploymentId: string
+  let manager: Contract
+  before(async () => {
+    const provider = hre.ethers.provider
+    const signer = provider.getSigner()
+    const signerAddress = await signer.getAddress()
+    const canonicalConfigPath = hre.config.paths.canonicalConfigs
+
+    const userConfig = await readUnvalidatedChugSplashConfig(configPath)
+
+    const artifactPaths = await getArtifactPaths(
+      hre,
+      userConfig.contracts,
+      hre.config.paths.artifacts,
+      path.join(hre.config.paths.artifacts, 'build-info')
+    )
+
+    const cre = await createChugSplashRuntime(
+      configPath,
+      true,
+      true,
+      hre.config.paths.canonicalConfigs,
+      hre,
+      // if the config parsing fails and exits with code 1, you should flip this to false to see verbose output
+      false
+    )
+
+    const parsedConfig = await readValidatedChugSplashConfig(
+      provider,
+      configPath,
+      artifactPaths,
+      'hardhat',
+      cre,
+      true
+    )
+
+    // claim
+    await chugsplashClaimAbstractTask(
+      provider,
+      signer,
+      parsedConfig,
+      true,
+      signerAddress,
+      'hardhat',
+      cre
+    )
+
+    const metatxs = await chugsplashProposeAbstractTask(
+      provider,
+      signer,
+      parsedConfig,
+      configPath,
+      '',
+      'hardhat',
+      artifactPaths,
+      canonicalConfigPath,
+      cre
+    )
+
+    const { request, signature, deploymentId } = metatxs!
+    expectedDeploymentId = deploymentId
+
+    const Forwarder = new Contract(
+      FORWARDER_ADDRESS,
+      ForwarderArtifact.abi,
+      signer
+    )
+
+    // Validate request on the forwarder contract
+    const valid = await Forwarder.verify(request, signature)
+    if (!valid) {
+      throw new Error(`Invalid metatxs request`)
+    }
+
+    // Send meta-tx through relayer to the forwarder contract
+    const gasLimit = (request.gas + 50000).toString()
+    await Forwarder.execute(request, signature, { gasLimit })
+    manager = await getChugSplashManager(
+      hre.ethers.provider,
+      parsedConfig.options.organizationID
+    )
+  })
+
+  it('does propose with meta txs', async () => {
+    const deployment = await manager.deployments(expectedDeploymentId)
+    expect(deployment).to.exist
+    expect(deployment.status).to.equal(1)
+  })
+
+  after(() => {
+    process.env['LOCAL_TEST_METATX_PROPOSE'] = 'false'
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,6 +1327,18 @@
     tweetnacl "^1.0.3"
     tweetnacl-util "^0.15.1"
 
+"@metamask/eth-sig-util@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-5.1.0.tgz#a47f62800ee1917fef976ba67544a0ccd7d1bd6b"
+  integrity sha512-mlgziIHYlA9pi/XZerChqg4NocdOgBPB9NmxgXWQO2U2hH8RGOJQrz6j/AIKkYxgCMIE2PY000+joOwXfzeTDQ==
+  dependencies:
+    "@ethereumjs/util" "^8.0.6"
+    bn.js "^4.12.0"
+    ethereum-cryptography "^2.0.0"
+    ethjs-util "^0.1.6"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.1"
+
 "@multiformats/base-x@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@multiformats/base-x/-/base-x-4.0.1.tgz#95ff0fa58711789d53aefb2590a8b7a4e715d121"
@@ -1624,9 +1636,9 @@
   integrity sha512-bQHV8R9Me8IaJoJ2vPG4rXcL7seB7YVuskr4f+f5RyOStSZetwzkWtoqDMl5erkBJy0lDRUnIR2WIkPiC0GJlg==
 
 "@openzeppelin/hardhat-upgrades@^1.22.1":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.25.0.tgz#7c40554d6d67e9e7693ac087a606798b214865ef"
-  integrity sha512-8kFCHMPLVdbegE4pItBmtEphK1dZE5rXIegOs2lgnOoGOuI+0hSpFNFlhFD8nYYP5YAsuFnxuFbCHVribWF4Rg==
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.25.1.tgz#e0a96f38a3948bb5b8db225bf0172e4b7e5de139"
+  integrity sha512-i9PGhyJRDALrvazNSsQWVUJkIwiZ9fMlidjwOEresBCzCdW8Npigoz4KSmfP78dgQ3kflDm/KWwCmyALnFgZNA==
   dependencies:
     "@openzeppelin/upgrades-core" "^1.26.0"
     chalk "^4.1.0"
@@ -1888,6 +1900,11 @@
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
 
+"@thirdweb-dev/contracts@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@thirdweb-dev/contracts/-/contracts-3.5.1.tgz#5d71c86203507006416085819267879fd8f4b6d3"
+  integrity sha512-P2UPEGxyK/kUAFlr3XBLzlZYKVyoIyoujIGCXCzAJ4bxkiWdHaeWR3x1WRLqlaBvFUb8Ldz9cyEqTsXBtXGBuQ==
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
@@ -1970,9 +1987,9 @@
   integrity sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==
 
 "@types/node@*", "@types/node@>=13.7.0":
-  version "20.1.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.1.1.tgz#afc492e8dbe7f672dd3a13674823522b467a45ad"
-  integrity sha512-uKBEevTNb+l6/aCQaKVnUModfEMjAl98lw2Si9P5y4hLu9tm6AlX2ZIoXZX6Wh9lJueYPrGPKk5WMCNHg/u6/A==
+  version "20.1.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.1.2.tgz#8fd63447e3f99aba6c3168fd2ec4580d5b97886f"
+  integrity sha512-CTO/wa8x+rZU626cL2BlbCDzydgnFNgc19h4YvizpTO88MFQxab8wqisxaofQJ/9bLGugRdWIuX/TbIs6VVF6g==
 
 "@types/node@^12.7.1":
   version "12.20.55"
@@ -1980,9 +1997,9 @@
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
 "@types/node@^18.0.0":
-  version "18.16.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.6.tgz#d0ffffe201b253989b17ea157ddabec677a4f4fe"
-  integrity sha512-N7KINmeB8IN3vRR8dhgHEp+YpWvGFcpDoh5XZ8jB5a00AdFKCKEyyGTOPTddUf4JqU1ZKTVxkOxakDvchNVI2Q==
+  version "18.16.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.7.tgz#86d0ba2541f808cb78d4dc5d3e40242a349d6db8"
+  integrity sha512-MFg7ua/bRtnA1hYE3pVyWxGd/r7aMqjNOdHvlSsXV3n8iaeGKkOaPzpJh6/ovf4bEXWcojkeMJpTsq3mzXW4IQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -2616,7 +2633,7 @@ bn.js@4.11.6:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
   integrity sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==
 
-bn.js@^4.11.0, bn.js@^4.11.8, bn.js@^4.11.9:
+bn.js@^4.11.0, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
@@ -3606,9 +3623,9 @@ electron-fetch@^1.7.2:
     encoding "^0.1.13"
 
 electron-to-chromium@^1.4.284:
-  version "1.4.388"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.388.tgz#ec0d1be823d5b14da56d91ec5c57e84b4624ea45"
-  integrity sha512-xZ0y4zjWZgp65okzwwt00f2rYibkFPHUv9qBz+Vzn8cB9UXIo9Zc6Dw81LJYhhNt0G/vR1OJEfStZ49NKl0YxQ==
+  version "1.4.391"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.391.tgz#197994210792e29e39baf3ce807df42f66e9b5f8"
+  integrity sha512-GqydVV1+kUWY5qlEzaw34/hyWTApuQrHiGrcGA2Kk/56nEK44i+YUW45VH43JuZT0Oo7uY8aVtpPhBBZXEWtSA==
 
 elliptic@6.5.4, elliptic@^6.5.2, elliptic@^6.5.4:
   version "6.5.4"
@@ -8852,9 +8869,9 @@ wcwidth@^1.0.1:
     defaults "^1.0.3"
 
 web3-utils@^1.3.4:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.9.0.tgz#7c5775a47586cefb4ad488831be8f6627be9283d"
-  integrity sha512-p++69rCNNfu2jM9n5+VD/g26l+qkEOQ1m6cfRQCbH8ZRrtquTmrirJMgTmyOoax5a5XRYOuws14aypCOs51pdQ==
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.10.0.tgz#ca4c1b431a765c14ac7f773e92e0fd9377ccf578"
+  integrity sha512-kSaCM0uMcZTNUSmn5vMEhlo02RObGNRRCkdX0V9UTAU0+lrvn0HSaudyCo6CQzuXUsnuY2ERJGCGPfeWmv19Rg==
   dependencies:
     bn.js "^5.2.1"
     ethereum-bloom-filters "^1.0.6"


### PR DESCRIPTION
## Purpose
Adds support for gasless proposals using meta transactions. Note that this includes an automated test that requires the use of IPFS credentials. 

## Testing
You must add the following environment variable and value to your plugin's `.env` file for the new test to work. Note this is just b/c we check for the API key to determine if a gasless proposal should be done or not. The value of the key doesn't matter right now. 
`CHUGSPLASH_API_KEY=testing`