### PR TITLE
fix(exec): Fix live network specific bugs

### DIFF
--- a/.changeset/twelve-rice-explain.md
+++ b/.changeset/twelve-rice-explain.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/executor': patch
+---
+
+Deploy and verify reference DefaultProxy and ChugSplashManagerProxy contracts

--- a/packages/core/config/goerli.ts
+++ b/packages/core/config/goerli.ts
@@ -1,8 +1,16 @@
 import { ChugSplashSystemConfig } from '../src'
 
 const config: ChugSplashSystemConfig = {
-  executors: ['0x42761FAcF5e6091fcA0e38F450adfB1E22bD8c3C'],
-  proposers: ['0xC034550B542b83BA1De312b21d1C94a9a52B1595'],
+  executors: [
+    '0x42761FAcF5e6091fcA0e38F450adfB1E22bD8c3C',
+    '0x4F2107d09B095B92f80ecd5b66C4004B87DC2652',
+    '0x791Cf9e43E0ca66b470E2a82Ec103d9e712623e2',
+  ],
+  proposers: [
+    '0xC034550B542b83BA1De312b21d1C94a9a52B1595',
+    '0x808923399391944164220074Ef3Cc6ad4701526f',
+    '0xb7e97060DE2DFfDcB39d765079A3ddd07d6E30A2',
+  ],
   callers: ['0xbdc60d8bac3d5741de797da2019acb6c3bb7ec15'],
 }
 

--- a/packages/core/src/addresses.ts
+++ b/packages/core/src/addresses.ts
@@ -23,6 +23,8 @@ import {
   DefaultCreate3Artifact,
   DefaultGasPriceCalculatorArtifact,
   FORWARDER_ADDRESS,
+  ChugSplashManagerProxyArtifact,
+  ProxyArtifact,
 } from '@chugsplash/contracts'
 import { constants, utils } from 'ethers'
 
@@ -41,6 +43,9 @@ const DefaultCreate3SourceName = DefaultCreate3Artifact.sourceName
 const DefaultGasPriceCalculatorSourceName =
   DefaultGasPriceCalculatorArtifact.sourceName
 const ManagedServiceSourceName = ManagedServiceArtifact.sourceName
+const chugsplashManagerProxySourceName =
+  ChugSplashManagerProxyArtifact.sourceName
+const proxyArtifactSourceName = ProxyArtifact.sourceName
 
 export const getRegistryConstructorValues = () => [getOwnerAddress()]
 
@@ -76,6 +81,38 @@ export const getManagedServiceAddress = () =>
       [
         ManagedServiceArtifact.bytecode,
         utils.defaultAbiCoder.encode(['address'], [getOwnerAddress()]),
+      ]
+    )
+  )
+
+export const getReferenceChugSplashManagerProxyAddress = () =>
+  utils.getCreate2Address(
+    DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
+    constants.HashZero,
+    utils.solidityKeccak256(
+      ['bytes', 'bytes'],
+      [
+        ChugSplashManagerProxyArtifact.bytecode,
+        utils.defaultAbiCoder.encode(
+          ['address', 'address'],
+          [getChugSplashRegistryAddress(), getChugSplashRegistryAddress()]
+        ),
+      ]
+    )
+  )
+
+export const getReferenceDefaultProxyAddress = () =>
+  utils.getCreate2Address(
+    DETERMINISTIC_DEPLOYMENT_PROXY_ADDRESS,
+    constants.HashZero,
+    utils.solidityKeccak256(
+      ['bytes', 'bytes'],
+      [
+        ProxyArtifact.bytecode,
+        utils.defaultAbiCoder.encode(
+          ['address'],
+          [getChugSplashRegistryAddress()]
+        ),
       ]
     )
   )
@@ -126,5 +163,10 @@ export const getChugSplashConstructorArgs = () => {
     [DefaultCreate3SourceName]: [],
     [DefaultGasPriceCalculatorSourceName]: [],
     [ManagedServiceSourceName]: [getOwnerAddress()],
+    [chugsplashManagerProxySourceName]: [
+      getChugSplashRegistryAddress(),
+      getChugSplashRegistryAddress(),
+    ],
+    [proxyArtifactSourceName]: [getChugSplashRegistryAddress()],
   }
 }

--- a/packages/core/src/languages/solidity/predeploys.ts
+++ b/packages/core/src/languages/solidity/predeploys.ts
@@ -43,6 +43,10 @@ import {
   DefaultCreate3Artifact,
   DefaultCreate3ABI,
   DEFAULT_CREATE3_ADDRESS,
+  ChugSplashManagerProxyABI,
+  ChugSplashManagerProxyArtifact,
+  ProxyABI,
+  ProxyArtifact,
 } from '@chugsplash/contracts'
 import { Logger } from '@eth-optimism/common-ts'
 
@@ -394,6 +398,34 @@ export const initializeChugSplash = async (
   )
 
   logger?.info('[ChugSplash]: DefaultAdapter deployed')
+
+  logger?.info('[ChugSplash]: deploying reference ChugSplashManagerProxy')
+
+  await doDeterministicDeploy(provider, {
+    signer: deployer,
+    contract: {
+      abi: ChugSplashManagerProxyABI,
+      bytecode: ChugSplashManagerProxyArtifact.bytecode,
+    },
+    args: chugsplashConstructorArgs[ChugSplashManagerProxyArtifact.sourceName],
+    salt: ethers.constants.HashZero,
+  })
+
+  logger?.info('[ChugSplash]: deployed reference ChugSplashManagerProxy')
+
+  logger?.info('[ChugSplash]: deploying reference Default Proxy')
+
+  await doDeterministicDeploy(provider, {
+    signer: deployer,
+    contract: {
+      abi: ProxyABI,
+      bytecode: ProxyArtifact.bytecode,
+    },
+    args: chugsplashConstructorArgs[ProxyArtifact.sourceName],
+    salt: ethers.constants.HashZero,
+  })
+
+  logger?.info('[ChugSplash]: deployed reference Default Proxy')
 
   // Make sure the addresses match, just in case.
   assert(

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1095,11 +1095,23 @@ export const getPreviousCanonicalConfig = async (
     )
   )
 
-  if (actionExecutedEvents.length === 0) {
+  const defaultProxyDeployedEvents = await ChugSplashRegistry.queryFilter(
+    ChugSplashRegistry.filters.EventAnnouncedWithData(
+      'DefaultProxyDeployed',
+      null,
+      proxyAddress
+    )
+  )
+
+  if (
+    actionExecutedEvents.length === 0 &&
+    defaultProxyDeployedEvents.length === 0
+  ) {
     return undefined
   }
 
-  const latestRegistryEvent = actionExecutedEvents.at(-1)
+  const latestRegistryEvent =
+    actionExecutedEvents.at(-1) ?? defaultProxyDeployedEvents.at(-1)
 
   if (latestRegistryEvent === undefined) {
     return undefined
@@ -1113,18 +1125,26 @@ export const getPreviousCanonicalConfig = async (
     provider
   )
 
-  const latestExecutionEvent = (
-    await ChugSplashManager.queryFilter(
-      ChugSplashManager.filters.SetProxyStorage(null, proxyAddress)
-    )
-  ).at(-1)
+  const latestExecutionEvent =
+    (
+      await ChugSplashManager.queryFilter(
+        ChugSplashManager.filters.SetProxyStorage(null, proxyAddress)
+      )
+    ).at(-1) ??
+    (
+      await ChugSplashManager.queryFilter(
+        ChugSplashManager.filters.DefaultProxyDeployed(null, proxyAddress)
+      )
+    ).at(-1)
 
   if (latestExecutionEvent === undefined) {
     throw new Error(
-      `SetProxyStorage event detected in registry but not in manager contract`
+      `SetProxyStorage or DefaultProxyDeployed event detected in registry but not in manager contract`
     )
   } else if (latestExecutionEvent.args === undefined) {
-    throw new Error(`SetProxyStorage event has no args.`)
+    throw new Error(
+      `SetProxyStorage or DefaultProxyDeployed event has no args.`
+    )
   }
 
   const latestProposalEvent = (

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -172,16 +172,25 @@ export class ChugSplashExecutor extends BaseServiceV2<
     )
 
     const currentTime = new Date()
-    const newExecutorEvents: ExecutorEvent[] = newApprovalEvents.map(
-      (event) => {
+    const newExecutorEvents: ExecutorEvent[] = newApprovalEvents
+      .map((event) => {
         return {
           retry: 1,
           nextTry: currentTime,
           waitingPeriodMs: 15000,
           event,
         }
-      }
-    )
+      })
+      // Filter out events that are already in the queue (happens due to some node providers doing inclusive filtering on block numbers)
+      .filter((e) => {
+        for (const event of this.state.eventsQueue) {
+          if (event.event.transactionHash === e.event.transactionHash) {
+            return false
+          }
+        }
+
+        return true
+      })
 
     // Concatenate the new approval events to the array
     this.state.eventsQueue = this.state.eventsQueue.concat(newExecutorEvents)


### PR DESCRIPTION
## Purpose
Fixes a variety of bugs caught during manual integration testing of the website.

- Fixes an issue where filtering for events results in duplicate events for some node providers depending on how they handle block number filtering. 
- Fixes an edge case where fetching the previous config from IPFS for the storage slot checker fails if the previous deployment did not include any set state actions.
- Fixes an issue where linking the default proxy to its implementation on Etherscan sometimes fails due to the default proxy not being verified.
- Adds steps to deploy and verify reference DefaultProxy and ChugSplashManagerProxy contracts so that contracts deployed by our factories will be automatically verified. 
- Adds logic to catch and retry Etherscan verification failures which sometimes occur due to us attempting to verify a contract before Etherscan has indexed it.