### PR TITLE
fix(core): fix behavior of create3 deployments

### DIFF
--- a/.changeset/six-ghosts-kick.md
+++ b/.changeset/six-ghosts-kick.md
@@ -1,0 +1,7 @@
+---
+'@chugsplash/contracts': patch
+'@chugsplash/plugins': patch
+'@chugsplash/core': patch
+---
+
+Fix behavior of contracts deployed using Create3

--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -2648,7 +2648,7 @@ const assertAvailableCreate3Addresses = async (
       if (match) {
         logValidationError(
           'warning',
-          `Skipping deployment of ${referenceName}. Add a new 'salt' value to re-deploy it at a new address.`,
+          `Skipping deployment of ${referenceName} since it has already been deployed and has not changed. Add a new 'salt' value to re-deploy it at a new address.`,
           [],
           cre.silent,
           cre.stream

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -123,7 +123,7 @@ export type ParsedContractConfig = {
   address: string
   kind: ContractKind
   variables: ParsedConfigVariables
-  userSalt: string
+  salt: string
   constructorArgs: ParsedConfigVariables
   unsafeAllowEmptyPush?: boolean
   unsafeAllowFlexibleConstructor?: boolean

--- a/packages/core/src/etherscan.ts
+++ b/packages/core/src/etherscan.ts
@@ -99,9 +99,7 @@ export const verifyChugSplashConfig = async (
     )
     const implementationAddress = getCreate3Address(
       managerAddress,
-      canonicalConfig.options.projectName,
-      referenceName,
-      contractConfig.userSalt
+      contractConfig.salt
     )
 
     const chugsplashInput = canonicalConfig.inputs.find((compilerInput) =>

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -333,12 +333,7 @@ export const displayDeploymentTable = (
         const address =
           contractConfig.kind !== 'no-proxy'
             ? contractConfig.address
-            : getCreate3Address(
-                managerAddress,
-                parsedConfig.options.projectName,
-                referenceName,
-                contractConfig.userSalt
-              )
+            : getCreate3Address(managerAddress, contractConfig.salt)
 
         const contractName = contractConfig.contract.includes(':')
           ? contractConfig.contract.split(':').at(-1)
@@ -784,7 +779,7 @@ export const isEqualType = (
   return isEqual
 }
 
-export const getCreate3Salt = (
+export const getNonProxyCreate3Salt = (
   projectName: string,
   referenceName: string,
   userSalt: string
@@ -805,15 +800,11 @@ export const getCreate3Salt = (
  */
 export const getCreate3Address = (
   managerAddress: string,
-  projectName: string,
-  referenceName: string,
-  userSalt: string
+  salt: string
 ): string => {
   // Hard-coded bytecode of the proxy used by Create3 to deploy the contract. See the `CREATE3.sol`
   // library for details.
   const proxyBytecode = '0x67363d3d37363d34f03d5260086018f3'
-
-  const salt = getCreate3Salt(projectName, referenceName, userSalt)
 
   const proxyAddress = utils.getCreate2Address(
     managerAddress,
@@ -1343,4 +1334,24 @@ export const deploymentDoesRevert = async (
     return true
   }
   return false
+}
+
+export const getDeployedCreationCodeWithArgsHash = async (
+  provider: providers.Provider,
+  organizationID: string,
+  referenceName: string,
+  contractAddress: string
+): Promise<string | undefined> => {
+  const ChugSplashManager = getChugSplashManager(provider, organizationID)
+
+  const events = await ChugSplashManager.queryFilter(
+    ChugSplashManager.filters.ContractDeployed(referenceName, contractAddress)
+  )
+
+  const latestEvent = events.at(-1)
+  if (!latestEvent || !latestEvent.args) {
+    return undefined
+  } else {
+    return latestEvent.args.creationCodeWithArgsHash
+  }
 }

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -17,6 +17,7 @@
     "test:forge": "anvil & ANVIL_PID=$! && forge test && kill $ANVIL_PID",
     "test:hardhat": "npx hardhat test --config-paths './chugsplash/Storage.config.ts, ./chugsplash/Create3.config.ts'",
     "test:coverage": "export DEV_FILE_PATH='./dist/foundry/index.js' && export DISABLE_ANALYTICS=true && IS_CHUGSPLASH_TEST=true && yarn test",
+    "test:kill": "kill $(lsof -t -i:8545)",
     "lint": "yarn lint:fix && yarn lint:check",
     "lint:fix": "yarn lint:ts:fix",
     "lint:check": "yarn lint:ts:check",

--- a/packages/plugins/src/foundry/index.ts
+++ b/packages/plugins/src/foundry/index.ts
@@ -17,6 +17,7 @@ import {
   getChugSplashManagerAddress,
   isLiveNetwork,
   ensureChugSplashInitialized,
+  getNonProxyCreate3Salt,
 } from '@chugsplash/core'
 import { ethers } from 'ethers'
 
@@ -395,9 +396,12 @@ const command = args[0]
       if (userConfig.contracts[referenceName].kind === 'no-proxy') {
         const address = getCreate3Address(
           managerAddress,
-          projectName,
-          referenceName,
-          userConfig.contracts[referenceName].salt ?? ethers.constants.HashZero
+          getNonProxyCreate3Salt(
+            projectName,
+            referenceName,
+            userConfig.contracts[referenceName].salt ??
+              ethers.constants.HashZero
+          )
         )
         process.stdout.write(address)
       } else {

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -14,6 +14,7 @@ import {
   readValidatedChugSplashConfig,
   getCreate3Address,
   getChugSplashManagerAddress,
+  getNonProxyCreate3Salt,
 } from '@chugsplash/core'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 
@@ -156,9 +157,11 @@ export const getContract = async (
   if (contractConfig.kind === 'no-proxy') {
     address = getCreate3Address(
       managerAddress,
-      projectName,
-      referenceName,
-      contractConfig.salt ?? ethers.constants.HashZero
+      getNonProxyCreate3Salt(
+        projectName,
+        referenceName,
+        contractConfig.salt ?? ethers.constants.HashZero
+      )
     )
   }
 

--- a/packages/plugins/test/Create3.spec.ts
+++ b/packages/plugins/test/Create3.spec.ts
@@ -3,7 +3,7 @@ import { chugsplash } from 'hardhat'
 import { Contract, ethers } from 'ethers'
 import '@nomiclabs/hardhat-ethers'
 
-describe('Salt', () => {
+describe('Create3', () => {
   let Stateless: Contract
   let StatelessWithSalt: Contract
   before(async () => {

--- a/packages/plugins/test/Validation.spec.ts
+++ b/packages/plugins/test/Validation.spec.ts
@@ -63,23 +63,31 @@ describe('Validate', () => {
       process.stderr
     )
 
-    await readValidatedChugSplashConfig(
-      provider,
-      variableValidateConfigPath,
-      varValidationArtifactPaths,
-      'hardhat',
-      cre,
-      false
-    )
+    try {
+      await readValidatedChugSplashConfig(
+        provider,
+        variableValidateConfigPath,
+        varValidationArtifactPaths,
+        'hardhat',
+        cre,
+        false
+      )
+    } catch (e) {
+      /* empty */
+    }
 
-    await readValidatedChugSplashConfig(
-      provider,
-      constructorArgConfigPath,
-      constructorArgsValidationArtifactPaths,
-      'hardhat',
-      cre,
-      false
-    )
+    try {
+      await readValidatedChugSplashConfig(
+        provider,
+        constructorArgConfigPath,
+        constructorArgsValidationArtifactPaths,
+        'hardhat',
+        cre,
+        false
+      )
+    } catch (e) {
+      /* empty */
+    }
 
     await assertValidUserConfigFields(
       noProxyValidationUserConfig,


### PR DESCRIPTION
When deploying a proxy's implementation via Create3, we now use a salt equal to `hash(creationCodeWithConstructorArgs)`. This essentially turns Create3 into Create2 for proxy implementations.

When deploying a non-proxy contract, we log a warning instead of an error when the contract at the Create3 address has a `hash(creationCodeWithConstructorArgs)` equal to the non-proxy contract in the config.