### PR TITLE
fix(core): Error if no API key is defined when proposing

### DIFF
--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -135,7 +135,8 @@ export const chugsplashProposeAbstractTask = async (
   integration: Integration,
   artifactPaths: ArtifactPaths,
   canonicalConfigPath: string,
-  cre: ChugSplashRuntimeEnvironment
+  cre: ChugSplashRuntimeEnvironment,
+  shouldRelay = true
 ) => {
   const { remoteExecution } = cre
 
@@ -210,12 +211,6 @@ export const chugsplashProposeAbstractTask = async (
     } else {
       spinner.succeed(`${parsedConfig.options.projectName} can be proposed.`)
       spinner.start(`Proposing ${parsedConfig.options.projectName}...`)
-
-      const shouldRelay =
-        process.env.CHUGSPLASH_API_KEY !== undefined &&
-        ((await isLiveNetwork(provider)) ||
-          process.env.LOCAL_TEST_METATX_PROPOSE === 'true' ||
-          process.env.LOCAL_MANAGED_SERVICE === 'true')
 
       const metatxs = await proposeChugSplashDeployment(
         provider,
@@ -1115,6 +1110,12 @@ export const proposeChugSplashDeployment = async (
     if (!process.env.PRIVATE_KEY) {
       throw new Error(
         'Must provide a PRIVATE_KEY environment variable to sign gasless proposal transactions'
+      )
+    }
+
+    if (!process.env.CHUGSPLASH_API_KEY) {
+      throw new Error(
+        'Must provide a CHUGSPLASH_API_KEY environment variable to use gasless proposals'
       )
     }
 

--- a/packages/executor/test/Executor.test.ts
+++ b/packages/executor/test/Executor.test.ts
@@ -87,7 +87,8 @@ describe('Remote Execution', () => {
       'hardhat',
       artifactPaths,
       canonicalConfigPath,
-      cre
+      cre,
+      false
     )
 
     // approve


### PR DESCRIPTION
## Purpose
Removes the complex logic for determining if we should use the relayer in the propose task or not, instead we just throw an error if the API key is not defined.