### PR TITLE
maint(core): remove `ArtifactPaths` in favor of `ConfigArtifacts`

### DIFF
--- a/packages/core/src/actions/artifacts.ts
+++ b/packages/core/src/actions/artifacts.ts
@@ -5,18 +5,14 @@ import {
   buildInfo as chugsplashBuildInfo,
 } from '@chugsplash/contracts'
 
-import { ParsedChugSplashConfig } from '../config/types'
+import { ConfigArtifacts, ParsedChugSplashConfig } from '../config/types'
 import {
-  ArtifactPaths,
   CompilerOutput,
   SolidityStorageLayout,
 } from '../languages/solidity/types'
-import { Integration } from '../constants'
 import {
   writeDeploymentFolderForNetwork,
   getConstructorArgs,
-  readBuildInfo,
-  readContractArtifact,
   writeDeploymentArtifact,
   getChugSplashManagerAddress,
 } from '../utils'
@@ -56,8 +52,7 @@ export const writeDeploymentArtifacts = async (
   deploymentEvents: ethers.Event[],
   networkName: string,
   deploymentFolderPath: string,
-  artifactPaths: ArtifactPaths,
-  integration: Integration
+  configArtifacts: ConfigArtifacts
 ) => {
   writeDeploymentFolderForNetwork(networkName, deploymentFolderPath)
 
@@ -118,14 +113,8 @@ export const writeDeploymentArtifacts = async (
     } else if (deploymentEvent.event === 'ContractDeployed') {
       // Get the deployed contract's info.
       const referenceName = deploymentEvent.args.referenceName
-      const artifact = readContractArtifact(
-        artifactPaths[referenceName].contractArtifactPath,
-        integration
-      )
+      const { artifact, buildInfo } = configArtifacts[referenceName]
       const { sourceName, contractName, bytecode, abi } = artifact
-      const buildInfo = readBuildInfo(
-        artifactPaths[referenceName].buildInfoPath
-      )
       const constructorArgValues = getConstructorArgs(
         parsedConfig.contracts[referenceName].constructorArgs,
         abi

--- a/packages/core/src/actions/bundle.ts
+++ b/packages/core/src/actions/bundle.ts
@@ -8,17 +8,13 @@ import {
   ParsedChugSplashConfig,
   contractKindHashes,
 } from '../config/types'
-import { Integration } from '../constants'
 import {
   computeStorageSegments,
   extendStorageLayout,
 } from '../languages/solidity/storage'
-import { ArtifactPaths } from '../languages/solidity/types'
 import {
   getCreate3Address,
-  readContractArtifact,
   getCreationCodeWithConstructorArgs,
-  readBuildInfo,
   getChugSplashManagerAddress,
 } from '../utils'
 import {
@@ -273,29 +269,6 @@ export const makeMerkleTree = (elements: string[]): MerkleTree => {
       return fromHexString(ethers.utils.keccak256(el))
     }
   )
-}
-
-export const bundleLocal = async (
-  provider: providers.Provider,
-  parsedConfig: ParsedChugSplashConfig,
-  artifactPaths: ArtifactPaths,
-  integration: Integration
-): Promise<ChugSplashBundles> => {
-  const artifacts: ConfigArtifacts = {}
-  for (const referenceName of Object.keys(parsedConfig.contracts)) {
-    const buildInfo = readBuildInfo(artifactPaths[referenceName].buildInfoPath)
-
-    const artifact = readContractArtifact(
-      artifactPaths[referenceName].contractArtifactPath,
-      integration
-    )
-    artifacts[referenceName] = {
-      buildInfo,
-      artifact,
-    }
-  }
-
-  return makeBundlesFromConfig(provider, parsedConfig, artifacts)
 }
 
 export const makeBundlesFromConfig = async (

--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -24,8 +24,6 @@ import yesno from 'yesno'
 import { ContractDefinition } from 'solidity-ast'
 
 import {
-  ArtifactPaths,
-  ContractArtifact,
   SolidityStorageLayout,
   SolidityStorageObj,
   SolidityStorageType,
@@ -34,8 +32,6 @@ import {
 import {
   getDefaultProxyAddress,
   isExternalContractKind,
-  readContractArtifact,
-  readBuildInfo,
   getChugSplashManagerAddress,
   getEIP1967ProxyAdminAddress,
   getPreviousStorageLayoutOZFormat,
@@ -61,6 +57,7 @@ import {
   UserConfigVariables,
   ParsedConfigVariables,
   ParsedContractConfig,
+  ConfigArtifacts,
 } from './types'
 import {
   CONTRACT_SIZE_LIMIT,
@@ -115,7 +112,7 @@ const logValidationError = (
 export const readValidatedChugSplashConfig = async (
   provider: providers.JsonRpcProvider,
   configPath: string,
-  artifactPaths: ArtifactPaths,
+  configArtifacts: ConfigArtifacts,
   integration: Integration,
   cre: ChugSplashRuntimeEnvironment,
   exitOnFailure: boolean = true
@@ -124,7 +121,7 @@ export const readValidatedChugSplashConfig = async (
   return parseAndValidateChugSplashConfig(
     provider,
     userConfig,
-    artifactPaths,
+    configArtifacts,
     integration,
     cre,
     exitOnFailure
@@ -1733,7 +1730,7 @@ export const assertValidParsedChugSplashFile = async (
   provider: providers.Provider,
   parsedConfig: ParsedChugSplashConfig,
   userConfig: UserChugSplashConfig,
-  artifactPaths: ArtifactPaths,
+  configArtifacts: ConfigArtifacts,
   cre: ChugSplashRuntimeEnvironment
 ): Promise<boolean> => {
   const { canonicalConfigPath } = cre
@@ -1831,9 +1828,7 @@ permission to call the 'upgradeTo' function on each of them.
   for (const [referenceName, contractConfig] of Object.entries(
     parsedConfig.contracts
   )) {
-    const { input, output } = readBuildInfo(
-      artifactPaths[referenceName].buildInfoPath
-    )
+    const { input, output } = configArtifacts[referenceName].buildInfo
     const userContractConfig = userConfig.contracts[referenceName]
 
     // First we do some validation on the contract that doesn't depend on whether or not we're performing an upgrade
@@ -1933,7 +1928,7 @@ permission to call the 'upgradeTo' function on each of them.
 
 export const assertValidSourceCode = (
   parsedConfig: ParsedChugSplashConfig,
-  artifactPaths: ArtifactPaths,
+  configArtifacts: ConfigArtifacts,
   cre: ChugSplashRuntimeEnvironment
 ) => {
   for (const [referenceName, contractConfig] of Object.entries(
@@ -1942,8 +1937,7 @@ export const assertValidSourceCode = (
     // Get the source name and contract name from its fully qualified name
     const [sourceName, contractName] = contractConfig.contract.split(':')
 
-    const buildInfoPath = artifactPaths[referenceName].buildInfoPath
-    const buildInfo = readBuildInfo(buildInfoPath)
+    const { buildInfo } = configArtifacts[referenceName]
 
     const sourceUnit = buildInfo.output.sources[sourceName].ast
     const decodeSrc = srcDecoder(buildInfo.input, buildInfo.output)
@@ -2127,35 +2121,24 @@ const logUnsafeOptions = (
 
 export const assertValidConstructorArgs = (
   userConfig: UserChugSplashConfig,
-  artifactPaths: ArtifactPaths,
+  configArtifacts: ConfigArtifacts,
   cre: ChugSplashRuntimeEnvironment,
-  exitOnFailure: boolean,
-  integration: Integration
+  exitOnFailure: boolean
 ): {
-  cachedCompilerOutput: { [referenceName: string]: CompilerOutput }
   cachedConstructorArgs: { [referenceName: string]: ParsedConfigVariables }
-  cachedArtifacts: { [referenceName: string]: ContractArtifact }
   contractReferences: { [referenceName: string]: string }
 } => {
   const { projectName, organizationID } = userConfig.options
   const managerAddress = getChugSplashManagerAddress(organizationID)
   // We cache the compiler output, constructor args, and other artifacts so we don't have to read them multiple times.
-  const cachedCompilerOutput = {}
   const cachedConstructorArgs = {}
   const contractReferences: { [referenceName: string]: string } = {}
-  const cachedArtifacts = {}
 
   // Determine the addresses for all proxied contracts and cache the artifacts.
   for (const [referenceName, userContractConfig] of Object.entries(
     userConfig.contracts
   )) {
     const { externalProxy, kind } = userContractConfig
-
-    const artifact = readContractArtifact(
-      artifactPaths[referenceName].contractArtifactPath,
-      integration
-    )
-    cachedArtifacts[referenceName] = artifact
 
     if (kind === 'no-proxy') {
       // prevents references to no-proxy contracts from being resolved to '' during the first pass compilation
@@ -2182,16 +2165,12 @@ export const assertValidConstructorArgs = (
   for (const [referenceName, userContractConfig] of Object.entries(
     userConfig.contracts
   )) {
-    const { output } = readBuildInfo(artifactPaths[referenceName].buildInfoPath)
-    cachedCompilerOutput[referenceName] = output
-
-    const artifact = cachedArtifacts[referenceName]
-    const { abi } = artifact
+    const { artifact } = configArtifacts[referenceName]
 
     const args = parseContractConstructorArgs(
       userContractConfig,
       referenceName,
-      abi,
+      artifact.abi,
       cre
     )
     cachedConstructorArgs[referenceName] = args
@@ -2234,21 +2213,14 @@ export const assertValidConstructorArgs = (
 
   // We return the cached values so we can use them in later steps without rereading the files
   return {
-    cachedCompilerOutput,
     cachedConstructorArgs: compiledConstructorArgs,
-    cachedArtifacts,
     contractReferences,
   }
 }
 
 const assertValidContractVariables = (
   userConfig: UserChugSplashConfig,
-  cachedCompilerOutput: {
-    [referenceName: string]: CompilerOutput
-  },
-  cachedArtifacts: {
-    [referenceName: string]: ContractArtifact
-  },
+  configArtifacts: ConfigArtifacts,
   contractReferences: { [referenceName: string]: string },
   cre: ChugSplashRuntimeEnvironment
 ): { [referenceName: string]: ParsedConfigVariables } => {
@@ -2271,12 +2243,11 @@ const assertValidContractVariables = (
       }
       parsedVariables[referenceName] = {}
     } else {
-      const artifact = cachedArtifacts[referenceName]
+      const { artifact, buildInfo } = configArtifacts[referenceName]
       const { sourceName, contractName } = artifact
 
-      const compilerOutput = cachedCompilerOutput[referenceName]
       const storageLayout = getStorageLayout(
-        compilerOutput,
+        buildInfo.output,
         sourceName,
         contractName
       )
@@ -2288,7 +2259,7 @@ const assertValidContractVariables = (
           })
         ),
         storageLayout,
-        compilerOutput,
+        buildInfo.output,
         cre
       )
 
@@ -2301,9 +2272,7 @@ const assertValidContractVariables = (
 
 const constructParsedConfig = (
   userConfig: UserChugSplashConfig,
-  cachedArtifacts: {
-    [referenceName: string]: ContractArtifact
-  },
+  configArtifacts: ConfigArtifacts,
   contractReferences: { [referenceName: string]: string },
   parsedVariables: { [referenceName: string]: ParsedConfigVariables },
   cachedConstructorArgs: { [referenceName: string]: ParsedConfigVariables }
@@ -2320,7 +2289,7 @@ const constructParsedConfig = (
     // executor to create the `ConfigArtifacts` when it eventually compiles the canonical
     // config.
     const { sourceName, contractName, bytecode, abi } =
-      cachedArtifacts[referenceName]
+      configArtifacts[referenceName].artifact
     const contractFullyQualifiedName = `${sourceName}:${contractName}`
 
     // If it's a non-proxy contract, the salt is a hash of the project name, reference name, and
@@ -2364,7 +2333,7 @@ const constructParsedConfig = (
 export const parseAndValidateChugSplashConfig = async (
   provider: providers.JsonRpcProvider,
   userConfig: UserChugSplashConfig,
-  artifactPaths: ArtifactPaths,
+  configArtifacts: ConfigArtifacts,
   integration: Integration,
   cre: ChugSplashRuntimeEnvironment,
   exitOnFailure: boolean = true
@@ -2383,24 +2352,13 @@ export const parseAndValidateChugSplashConfig = async (
   // Parse and validate contract constructor args
   // During this function, we also resolve all contract references throughout the entire config b/c constructor args may impact contract addresses
   // We also cache the compiler output, parsed constructor args, and other artifacts so we don't have to re-read them later
-  const {
-    cachedCompilerOutput,
-    cachedConstructorArgs,
-    cachedArtifacts,
-    contractReferences,
-  } = assertValidConstructorArgs(
-    userConfig,
-    artifactPaths,
-    cre,
-    exitOnFailure,
-    integration
-  )
+  const { cachedConstructorArgs, contractReferences } =
+    assertValidConstructorArgs(userConfig, configArtifacts, cre, exitOnFailure)
 
   // Parse and validate contract variables
   const parsedVariables = assertValidContractVariables(
     userConfig,
-    cachedCompilerOutput,
-    cachedArtifacts,
+    configArtifacts,
     contractReferences,
     cre
   )
@@ -2408,20 +2366,19 @@ export const parseAndValidateChugSplashConfig = async (
   // Construct the parsed config
   const parsedConfig = constructParsedConfig(
     userConfig,
-    cachedArtifacts,
+    configArtifacts,
     contractReferences,
     parsedVariables,
     cachedConstructorArgs
   )
 
-  assertValidSourceCode(parsedConfig, artifactPaths, cre)
+  assertValidSourceCode(parsedConfig, configArtifacts, cre)
 
   await assertAvailableCreate3Addresses(
     provider,
     parsedConfig,
-    artifactPaths,
-    cre,
-    integration
+    configArtifacts,
+    cre
   )
 
   const managerAddress = getChugSplashManagerAddress(
@@ -2431,13 +2388,13 @@ export const parseAndValidateChugSplashConfig = async (
     provider,
     managerAddress,
     parsedConfig,
-    cachedArtifacts,
+    configArtifacts,
     cachedConstructorArgs,
     cre
   )
 
   if (await isLiveNetwork(provider)) {
-    await assertContractsBelowSizeLimit(parsedConfig, cachedArtifacts, cre)
+    await assertContractsBelowSizeLimit(parsedConfig, configArtifacts, cre)
   }
 
   await assertValidDeploymentSize(provider, parsedConfig, cre)
@@ -2448,7 +2405,7 @@ export const parseAndValidateChugSplashConfig = async (
     provider,
     parsedConfig,
     userConfig,
-    artifactPaths,
+    configArtifacts,
     cre
   )
 
@@ -2521,16 +2478,14 @@ export const assertValidDeploymentSize = async (
  */
 export const assertContractsBelowSizeLimit = async (
   parsedConfig: ParsedChugSplashConfig,
-  artifacts: {
-    [referenceName: string]: ContractArtifact
-  },
+  configArtifacts: ConfigArtifacts,
   cre: ChugSplashRuntimeEnvironment
 ) => {
   const tooLarge: string[] = []
   for (const [referenceName, contractConfig] of Object.entries(
     parsedConfig.contracts
   )) {
-    const deployedBytecode = artifacts[referenceName].deployedBytecode
+    const { deployedBytecode } = configArtifacts[referenceName].artifact
 
     const numBytes = (deployedBytecode.length - 2) / 2
     if (numBytes > CONTRACT_SIZE_LIMIT) {
@@ -2554,13 +2509,13 @@ export const assertNonProxyDeploymentsDoNotRevert = async (
   provider: providers.Provider,
   managerAddress: string,
   parsedConfig: ParsedChugSplashConfig,
-  artifacts: { [referenceName: string]: ContractArtifact },
+  configArtifacts: ConfigArtifacts,
   constructorArgs: { [referenceName: string]: ParsedConfigVariables },
   cre: ChugSplashRuntimeEnvironment
 ) => {
   const revertingDeployments: { [referenceName: string]: string } = {}
 
-  for (const [referenceName, artifact] of Object.entries(artifacts)) {
+  for (const [referenceName, { artifact }] of Object.entries(configArtifacts)) {
     // Skip proxies. We check that they have deterministic constructors elsewhere (in
     // `assertValidSourceCode`).
     if (parsedConfig.contracts[referenceName].kind !== 'no-proxy') {
@@ -2604,9 +2559,8 @@ export const assertNonProxyDeploymentsDoNotRevert = async (
 const assertAvailableCreate3Addresses = async (
   provider: providers.Provider,
   parsedConfig: ParsedChugSplashConfig,
-  artifactPaths: ArtifactPaths,
-  cre: ChugSplashRuntimeEnvironment,
-  integration: Integration
+  configArtifacts: ConfigArtifacts,
+  cre: ChugSplashRuntimeEnvironment
 ): Promise<void> => {
   // List of reference names that correspond to the unavailable Create3 addresses
   const unavailable: string[] = []
@@ -2618,10 +2572,7 @@ const assertAvailableCreate3Addresses = async (
       contractConfig.kind === 'no-proxy' &&
       (await provider.getCode(contractConfig.address)) !== '0x'
     ) {
-      const { bytecode, abi } = readContractArtifact(
-        artifactPaths[referenceName].contractArtifactPath,
-        integration
-      )
+      const { bytecode, abi } = configArtifacts[referenceName].artifact
 
       const deployedHash = await getDeployedCreationCodeWithArgsHash(
         provider,

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -10,10 +10,9 @@ import {
   DeploymentStatus,
   writeDeploymentArtifacts,
 } from '../actions'
-import { ParsedChugSplashConfig } from '../config'
+import { ConfigArtifacts, ParsedChugSplashConfig } from '../config'
 import { Integration } from '../constants'
 import { getAmountToDeposit } from '../fund'
-import { ArtifactPaths } from '../languages'
 import {
   getChugSplashManager,
   getDeploymentEvents,
@@ -141,7 +140,7 @@ export const postExecutionActions = async (
   deploymentEvents: ethers.Event[],
   networkName: string,
   deploymentFolderPath: string,
-  artifactPaths: ArtifactPaths,
+  configArtifacts: ConfigArtifacts,
   integration: Integration,
   newProjectOwner?: string | undefined,
   spinner: ora.Ora = ora({ isSilent: true })
@@ -185,8 +184,7 @@ export const postExecutionActions = async (
     deploymentEvents,
     networkName,
     deploymentFolderPath,
-    artifactPaths,
-    integration
+    configArtifacts
   )
 
   spinner.succeed(`Wrote deployment artifacts.`)

--- a/packages/core/src/languages/solidity/types.ts
+++ b/packages/core/src/languages/solidity/types.ts
@@ -52,16 +52,6 @@ export interface ExtendedStorageLayout extends SolidityStorageLayout {
   storage: ExtendedSolidityStorageObj[]
 }
 
-/**
- * Mapping from a contract's reference name to its build info file path and artifact path.
- */
-export type ArtifactPaths = {
-  [referenceName: string]: {
-    buildInfoPath: string
-    contractArtifactPath: string
-  }
-}
-
 export interface StorageSlotSegment {
   key: string
   offset: number

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -64,7 +64,6 @@ import {
   ContractArtifact,
   BuildInfo,
   CompilerOutput,
-  ArtifactPaths,
 } from './languages/solidity/types'
 import { chugsplashFetchSubtask } from './config/fetch'
 import { getSolcBuild } from './languages'
@@ -318,7 +317,6 @@ export const chugsplashLog = (
 
 export const displayDeploymentTable = (
   parsedConfig: ParsedChugSplashConfig,
-  artifactPaths: ArtifactPaths,
   integration: Integration,
   silent: boolean
 ) => {

--- a/packages/executor/test/Executor.test.ts
+++ b/packages/executor/test/Executor.test.ts
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import '@chugsplash/plugins'
 
 import hre, { chugsplash } from 'hardhat'
@@ -12,8 +11,8 @@ import {
   readValidatedChugSplashConfig,
 } from '@chugsplash/core'
 import { expect } from 'chai'
+import { getConfigArtifacts } from '@chugsplash/plugins/src/hardhat/artifacts'
 
-import { getArtifactPaths } from '../../plugins/dist'
 import { createChugSplashRuntime } from '../../plugins/src/utils'
 
 const configPath = './chugsplash/ExecutorTest.config.ts'
@@ -30,12 +29,7 @@ describe('Remote Execution', () => {
 
     const userConfig = await readUnvalidatedChugSplashConfig(configPath)
 
-    const artifactPaths = await getArtifactPaths(
-      hre,
-      userConfig.contracts,
-      hre.config.paths.artifacts,
-      path.join(hre.config.paths.artifacts, 'build-info')
-    )
+    const configArtifacts = await getConfigArtifacts(hre, userConfig.contracts)
 
     const cre = await createChugSplashRuntime(
       configPath,
@@ -50,7 +44,7 @@ describe('Remote Execution', () => {
     const parsedConfig = await readValidatedChugSplashConfig(
       provider,
       configPath,
-      artifactPaths,
+      configArtifacts,
       'hardhat',
       cre,
       true
@@ -72,7 +66,7 @@ describe('Remote Execution', () => {
       provider,
       signer,
       configPath,
-      artifactPaths,
+      configArtifacts,
       'hardhat',
       parsedConfig,
       cre
@@ -85,7 +79,7 @@ describe('Remote Execution', () => {
       configPath,
       '',
       'hardhat',
-      artifactPaths,
+      configArtifacts,
       canonicalConfigPath,
       cre,
       false
@@ -97,7 +91,7 @@ describe('Remote Execution', () => {
       signer,
       configPath,
       false,
-      artifactPaths,
+      configArtifacts,
       'hardhat',
       canonicalConfigPath,
       deploymentFolder,

--- a/packages/plugins/src/foundry/index.ts
+++ b/packages/plugins/src/foundry/index.ts
@@ -21,7 +21,7 @@ import {
 } from '@chugsplash/core'
 import { ethers } from 'ethers'
 
-import { cleanPath, fetchPaths, getArtifactPaths } from './utils'
+import { cleanPath, fetchPaths, getConfigArtifacts } from './utils'
 import { createChugSplashRuntime } from '../utils'
 
 const args = process.argv.slice(2)
@@ -57,7 +57,7 @@ const command = args[0]
       const wallet = new ethers.Wallet(privateKey, provider)
 
       const userConfig = await readUnvalidatedChugSplashConfig(configPath)
-      const artifactPaths = await getArtifactPaths(
+      const configArtifacts = await getConfigArtifacts(
         userConfig.contracts,
         artifactFolder,
         buildInfoFolder
@@ -66,12 +66,11 @@ const command = args[0]
       const config = await readValidatedChugSplashConfig(
         provider,
         configPath,
-        artifactPaths,
+        configArtifacts,
         'foundry',
         cre
       )
 
-      await provider.getNetwork()
       const address = await wallet.getAddress()
       owner = owner !== 'self' ? owner : address
 
@@ -115,7 +114,7 @@ const command = args[0]
       )
 
       const userConfig = await readUnvalidatedChugSplashConfig(configPath)
-      const artifactPaths = await getArtifactPaths(
+      const configArtifacts = await getConfigArtifacts(
         userConfig.contracts,
         artifactFolder,
         buildInfoFolder
@@ -125,13 +124,10 @@ const command = args[0]
       const config = await readValidatedChugSplashConfig(
         provider,
         configPath,
-        artifactPaths,
+        configArtifacts,
         'foundry',
         cre
       )
-
-      await provider.getNetwork()
-      await wallet.getAddress()
 
       if (!silent) {
         console.log('-- ChugSplash Propose --')
@@ -143,7 +139,7 @@ const command = args[0]
         configPath,
         ipfsUrl,
         'foundry',
-        artifactPaths,
+        configArtifacts,
         canonicalConfigPath,
         cre
       )
@@ -190,21 +186,21 @@ const command = args[0]
       )
 
       const userConfig = await readUnvalidatedChugSplashConfig(configPath)
-      const artifactPaths = await getArtifactPaths(
+      const configArtifacts = await getConfigArtifacts(
         userConfig.contracts,
         artifactFolder,
         buildInfoFolder
       )
 
       const wallet = new ethers.Wallet(privateKey, provider)
-      await provider.getNetwork()
+
       const address = await wallet.getAddress()
       newOwner = newOwner !== 'self' ? newOwner : address
 
       const parsedConfig = await readValidatedChugSplashConfig(
         provider,
         configPath,
-        artifactPaths,
+        configArtifacts,
         'foundry',
         cre
       )
@@ -218,7 +214,7 @@ const command = args[0]
         wallet,
         configPath,
         newOwner ?? (await wallet.getAddress()),
-        artifactPaths,
+        configArtifacts,
         canonicalConfigPath,
         deploymentFolder,
         'foundry',
@@ -244,8 +240,6 @@ const command = args[0]
 
       const provider = new ethers.providers.JsonRpcProvider(rpcUrl, network)
       const wallet = new ethers.Wallet(privateKey, provider)
-      await provider.getNetwork()
-      await wallet.getAddress()
 
       const cre = await createChugSplashRuntime(
         configPath,
@@ -274,8 +268,6 @@ const command = args[0]
 
       const provider = new ethers.providers.JsonRpcProvider(rpcUrl, network)
       const wallet = new ethers.Wallet(privateKey, provider)
-      await provider.getNetwork()
-      await wallet.getAddress()
 
       const cre = await createChugSplashRuntime(
         '',
@@ -316,20 +308,18 @@ const command = args[0]
       )
 
       const userConfig = await readUnvalidatedChugSplashConfig(configPath)
-      const artifactPaths = await getArtifactPaths(
+      const configArtifacts = await getConfigArtifacts(
         userConfig.contracts,
         artifactFolder,
         buildInfoFolder
       )
 
       const wallet = new ethers.Wallet(privateKey, provider)
-      await provider.getNetwork()
-      await wallet.getAddress()
 
       const parsedConfig = await readValidatedChugSplashConfig(
         provider,
         configPath,
-        artifactPaths,
+        configArtifacts,
         'foundry',
         cre
       )
@@ -358,8 +348,6 @@ const command = args[0]
 
       const provider = new ethers.providers.JsonRpcProvider(rpcUrl, network)
       const wallet = new ethers.Wallet(privateKey, provider)
-      await provider.getNetwork()
-      await wallet.getAddress()
 
       const cre = await createChugSplashRuntime(
         configPath,

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -2,8 +2,8 @@ import * as path from 'path'
 import * as fs from 'fs'
 
 import {
-  ArtifactPaths,
   BuildInfo,
+  ConfigArtifacts,
   ContractArtifact,
   parseFoundryArtifact,
   UserContractConfigs,
@@ -61,32 +61,28 @@ export const getContractArtifact = (
   return parseFoundryArtifact(artifact)
 }
 
-export const getArtifactPaths = async (
+export const getConfigArtifacts = async (
   contractConfigs: UserContractConfigs,
   artifactFolder: string,
   buildInfoFolder: string
-): Promise<ArtifactPaths> => {
-  const artifactPaths: ArtifactPaths = {}
+): Promise<ConfigArtifacts> => {
+  const configArtifacts: ConfigArtifacts = {}
 
   for (const [referenceName, contractConfig] of Object.entries(
     contractConfigs
   )) {
-    const { sourceName, contractName } = getContractArtifact(
+    const artifact = getContractArtifact(
       contractConfig.contract,
       artifactFolder
     )
-    const buildInfo = await getBuildInfo(buildInfoFolder, sourceName)
+    const buildInfo = getBuildInfo(buildInfoFolder, artifact.sourceName)
 
-    const folderName = `${contractName}.sol`
-    const fileName = `${contractName}.json`
-    const contractArtifactPath = path.join(artifactFolder, folderName, fileName)
-
-    artifactPaths[referenceName] = {
-      buildInfoPath: path.join(buildInfoFolder, `${buildInfo.id}.json`),
-      contractArtifactPath,
+    configArtifacts[referenceName] = {
+      artifact,
+      buildInfo,
     }
   }
-  return artifactPaths
+  return configArtifacts
 }
 
 export const cleanPath = (dirtyPath: string) => {

--- a/packages/plugins/src/hardhat/artifacts.ts
+++ b/packages/plugins/src/hardhat/artifacts.ts
@@ -2,12 +2,12 @@ import path from 'path'
 
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import {
-  ArtifactPaths,
   UserContractConfigs,
   getEIP1967ProxyImplementationAddress,
   BuildInfo,
   ParsedContractConfig,
   toOpenZeppelinContractKind,
+  ConfigArtifacts,
 } from '@chugsplash/core'
 import {
   Manifest,
@@ -69,30 +69,26 @@ export const getBuildInfo = async (
  * @param buildInfoFolder Path to the build info folder.
  * @returns Paths to the build info and contract artifact files.
  */
-export const getArtifactPaths = async (
+export const getConfigArtifacts = async (
   hre: HardhatRuntimeEnvironment,
-  contractConfigs: UserContractConfigs,
-  artifactFolder: string,
-  buildInfoFolder: string
-): Promise<ArtifactPaths> => {
-  const artifactPaths: ArtifactPaths = {}
+  contractConfigs: UserContractConfigs
+): Promise<ConfigArtifacts> => {
+  const configArtifacts: ConfigArtifacts = {}
   for (const [referenceName, contractConfig] of Object.entries(
     contractConfigs
   )) {
-    const { sourceName, contractName } = hre.artifacts.readArtifactSync(
-      contractConfig.contract
+    const artifact = hre.artifacts.readArtifactSync(contractConfig.contract)
+    const buildInfo = await getBuildInfo(
+      hre,
+      artifact.sourceName,
+      artifact.contractName
     )
-    const buildInfo = await getBuildInfo(hre, sourceName, contractName)
-    artifactPaths[referenceName] = {
-      buildInfoPath: path.join(buildInfoFolder, `${buildInfo.id}.json`),
-      contractArtifactPath: path.join(
-        artifactFolder,
-        sourceName,
-        `${contractName}.json`
-      ),
+    configArtifacts[referenceName] = {
+      artifact,
+      buildInfo,
     }
   }
-  return artifactPaths
+  return configArtifacts
 }
 
 /**

--- a/packages/plugins/src/hardhat/deployments.ts
+++ b/packages/plugins/src/hardhat/deployments.ts
@@ -18,7 +18,7 @@ import {
 } from '@chugsplash/core'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 
-import { getArtifactPaths } from './artifacts'
+import { getConfigArtifacts } from './artifacts'
 import { createChugSplashRuntime } from '../utils'
 
 export const fetchFilesRecursively = (dir): string[] => {
@@ -71,17 +71,12 @@ export const deployAllChugSplashConfigs = async (
     }
     const userConfig = await readUnvalidatedChugSplashConfig(configPath)
 
-    const artifactPaths = await getArtifactPaths(
-      hre,
-      userConfig.contracts,
-      hre.config.paths.artifacts,
-      path.join(hre.config.paths.artifacts, 'build-info')
-    )
+    const configArtifacts = await getConfigArtifacts(hre, userConfig.contracts)
 
     const parsedConfig = await readValidatedChugSplashConfig(
       hre.ethers.provider,
       configPath,
-      artifactPaths,
+      configArtifacts,
       'hardhat',
       cre,
       true
@@ -93,7 +88,7 @@ export const deployAllChugSplashConfigs = async (
       hre.ethers.provider.getSigner(),
       configPath,
       await signer.getAddress(),
-      artifactPaths,
+      configArtifacts,
       canonicalConfigPath,
       deploymentFolder,
       'hardhat',

--- a/packages/plugins/src/scripts/display-bundle-info.ts
+++ b/packages/plugins/src/scripts/display-bundle-info.ts
@@ -1,4 +1,3 @@
-import path from 'path'
 import { argv } from 'node:process'
 
 import hre from 'hardhat'
@@ -10,7 +9,7 @@ import {
 } from '@chugsplash/core'
 import { utils } from 'ethers'
 
-import { getArtifactPaths } from '../hardhat/artifacts'
+import { getConfigArtifacts } from '../hardhat/artifacts'
 import { createChugSplashRuntime } from '../utils'
 
 const chugsplashFilePath = argv[2]
@@ -27,12 +26,7 @@ if (typeof chugsplashFilePath !== 'string') {
  */
 const displayBundleInfo = async () => {
   const userConfig = await readUnvalidatedChugSplashConfig(chugsplashFilePath)
-  const artifactPaths = await getArtifactPaths(
-    hre,
-    userConfig.contracts,
-    hre.config.paths.artifacts,
-    path.join(hre.config.paths.artifacts, 'build-info')
-  )
+  const configArtifacts = await getConfigArtifacts(hre, userConfig.contracts)
 
   const cre = await createChugSplashRuntime(
     chugsplashFilePath,
@@ -46,7 +40,7 @@ const displayBundleInfo = async () => {
   const parsedConfig = await readValidatedChugSplashConfig(
     hre.ethers.provider,
     chugsplashFilePath,
-    artifactPaths,
+    configArtifacts,
     'hardhat',
     cre
   )
@@ -56,7 +50,7 @@ const displayBundleInfo = async () => {
     parsedConfig,
     '',
     false,
-    artifactPaths,
+    configArtifacts,
     hre.config.paths.canonicalConfigs,
     'hardhat'
   )

--- a/packages/plugins/test/Metatx.spec.ts
+++ b/packages/plugins/test/Metatx.spec.ts
@@ -1,5 +1,3 @@
-import * as path from 'path'
-
 import hre from 'hardhat'
 import { Contract } from 'ethers'
 import {
@@ -12,8 +10,8 @@ import {
 import { FORWARDER_ADDRESS, ForwarderArtifact } from '@chugsplash/contracts'
 import { expect } from 'chai'
 
-import { getArtifactPaths } from '../../plugins/dist'
 import { createChugSplashRuntime } from '../../plugins/src/utils'
+import { getConfigArtifacts } from '../src/hardhat/artifacts'
 
 const configPath = './chugsplash/Metatx.config.ts'
 
@@ -30,12 +28,7 @@ describe('Meta txs', () => {
 
     const userConfig = await readUnvalidatedChugSplashConfig(configPath)
 
-    const artifactPaths = await getArtifactPaths(
-      hre,
-      userConfig.contracts,
-      hre.config.paths.artifacts,
-      path.join(hre.config.paths.artifacts, 'build-info')
-    )
+    const configArtifacts = await getConfigArtifacts(hre, userConfig.contracts)
 
     const cre = await createChugSplashRuntime(
       configPath,
@@ -50,7 +43,7 @@ describe('Meta txs', () => {
     const parsedConfig = await readValidatedChugSplashConfig(
       provider,
       configPath,
-      artifactPaths,
+      configArtifacts,
       'hardhat',
       cre,
       true
@@ -74,7 +67,7 @@ describe('Meta txs', () => {
       configPath,
       '',
       'hardhat',
-      artifactPaths,
+      configArtifacts,
       canonicalConfigPath,
       cre
     )

--- a/packages/plugins/test/Transfer.spec.ts
+++ b/packages/plugins/test/Transfer.spec.ts
@@ -1,5 +1,3 @@
-import * as path from 'path'
-
 // Hardhat plugins
 import '@nomiclabs/hardhat-ethers'
 import '@openzeppelin/hardhat-upgrades'
@@ -22,7 +20,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import * as ProxyAdminArtifact from '@openzeppelin/contracts/build/contracts/ProxyAdmin.json'
 
 import { createChugSplashRuntime } from '../src/utils'
-import { getArtifactPaths } from '../src/hardhat/artifacts'
+import { getConfigArtifacts } from '../src/hardhat/artifacts'
 const uupsOwnableUpgradeConfigPath =
   './chugsplash/hardhat/UUPSOwnableUpgradableUpgrade.config.ts'
 const uupsAccessControlUpgradeConfigPath =
@@ -75,12 +73,7 @@ describe('Transfer', () => {
       transparentUpgradeConfigPath
     )
 
-    const artifactPaths = await getArtifactPaths(
-      hre,
-      userConfig.contracts,
-      hre.config.paths.artifacts,
-      path.join(hre.config.paths.artifacts, 'build-info')
-    )
+    const configArtifacts = await getConfigArtifacts(hre, userConfig.contracts)
 
     const cre = await createChugSplashRuntime(
       transparentUpgradeConfigPath,
@@ -122,7 +115,7 @@ describe('Transfer', () => {
     const parsedConfig = await readValidatedChugSplashConfig(
       provider,
       transparentUpgradeConfigPath,
-      artifactPaths,
+      configArtifacts,
       'hardhat',
       cre,
       false
@@ -133,7 +126,7 @@ describe('Transfer', () => {
       signer,
       transparentUpgradeConfigPath,
       signer.address,
-      artifactPaths,
+      configArtifacts,
       canonicalConfigPath,
       deploymentFolder,
       'hardhat',
@@ -190,12 +183,7 @@ describe('Transfer', () => {
       uupsOwnableUpgradeConfigPath
     )
 
-    const artifactPaths = await getArtifactPaths(
-      hre,
-      userConfig.contracts,
-      hre.config.paths.artifacts,
-      path.join(hre.config.paths.artifacts, 'build-info')
-    )
+    const configArtifacts = await getConfigArtifacts(hre, userConfig.contracts)
 
     const cre = await createChugSplashRuntime(
       uupsOwnableUpgradeConfigPath,
@@ -232,7 +220,7 @@ describe('Transfer', () => {
     const parsedConfig = await readValidatedChugSplashConfig(
       provider,
       uupsOwnableUpgradeConfigPath,
-      artifactPaths,
+      configArtifacts,
       'hardhat',
       cre,
       false
@@ -245,7 +233,7 @@ describe('Transfer', () => {
       signer,
       uupsOwnableUpgradeConfigPath,
       signer.address,
-      artifactPaths,
+      configArtifacts,
       canonicalConfigPath,
       deploymentFolder,
       'hardhat',
@@ -322,12 +310,7 @@ describe('Transfer', () => {
       uupsAccessControlUpgradeConfigPath
     )
 
-    const artifactPaths = await getArtifactPaths(
-      hre,
-      userConfig.contracts,
-      hre.config.paths.artifacts,
-      path.join(hre.config.paths.artifacts, 'build-info')
-    )
+    const configArtifacts = await getConfigArtifacts(hre, userConfig.contracts)
 
     const cre = await createChugSplashRuntime(
       uupsAccessControlUpgradeConfigPath,
@@ -369,7 +352,7 @@ describe('Transfer', () => {
     const parsedConfig = await readValidatedChugSplashConfig(
       provider,
       uupsAccessControlUpgradeConfigPath,
-      artifactPaths,
+      configArtifacts,
       'hardhat',
       cre,
       false
@@ -383,7 +366,7 @@ describe('Transfer', () => {
       signer,
       uupsAccessControlUpgradeConfigPath,
       signer.address,
-      artifactPaths,
+      configArtifacts,
       canonicalConfigPath,
       deploymentFolder,
       'hardhat',

--- a/packages/plugins/test/Validation.spec.ts
+++ b/packages/plugins/test/Validation.spec.ts
@@ -1,5 +1,3 @@
-import * as path from 'path'
-
 // Hardhat plugins
 import '@nomiclabs/hardhat-ethers'
 import '@openzeppelin/hardhat-upgrades'
@@ -13,7 +11,7 @@ import {
   readValidatedChugSplashConfig,
 } from '@chugsplash/core'
 
-import { getArtifactPaths } from '../src/hardhat/artifacts'
+import { getConfigArtifacts } from '../src/hardhat/artifacts'
 import { createChugSplashRuntime } from '../src/utils'
 
 const variableValidateConfigPath = './chugsplash/VariableValidation.config.ts'
@@ -35,17 +33,13 @@ describe('Validate', () => {
     const noProxyValidationUserConfig = await readUnvalidatedChugSplashConfig(
       noProxyContractReferenceConfigPath
     )
-    const varValidationArtifactPaths = await getArtifactPaths(
+    const varValidationArtifacts = await getConfigArtifacts(
       hre,
-      varValidationUserConfig.contracts,
-      hre.config.paths.artifacts,
-      path.join(hre.config.paths.artifacts, 'build-info')
+      varValidationUserConfig.contracts
     )
-    const constructorArgsValidationArtifactPaths = await getArtifactPaths(
+    const constructorArgsValidationArtifacts = await getConfigArtifacts(
       hre,
-      constructorArgsValidationUserConfig.contracts,
-      hre.config.paths.artifacts,
-      path.join(hre.config.paths.artifacts, 'build-info')
+      constructorArgsValidationUserConfig.contracts
     )
 
     process.stderr.write = (message: string) => {
@@ -67,7 +61,7 @@ describe('Validate', () => {
       await readValidatedChugSplashConfig(
         provider,
         variableValidateConfigPath,
-        varValidationArtifactPaths,
+        varValidationArtifacts,
         'hardhat',
         cre,
         false
@@ -80,7 +74,7 @@ describe('Validate', () => {
       await readValidatedChugSplashConfig(
         provider,
         constructorArgConfigPath,
-        constructorArgsValidationArtifactPaths,
+        constructorArgsValidationArtifacts,
         'hardhat',
         cre,
         false


### PR DESCRIPTION
This removes a lot of unnecessary file I/O, which should speed things up a bit. Using a single persistent object for the artifacts also makes it easy to modify the build info objects, which is necessary while [this Foundry bug](https://github.com/foundry-rs/foundry/issues/4981) is pending.