### PR TITLE
fix(pg): change hardhat `node` task param from `silent` to `hide`

### DIFF
--- a/.changeset/slimy-humans-sniff.md
+++ b/.changeset/slimy-humans-sniff.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/plugins': patch
+---
+
+Change Hardhat `node` task param from 'silent' to 'hide' due to conflict with existing task

--- a/packages/plugins/src/hardhat/tasks.ts
+++ b/packages/plugins/src/hardhat/tasks.ts
@@ -532,21 +532,21 @@ task(TASK_NODE)
     'disableChugsplash',
     "Completely disable all of ChugSplash's activity."
   )
-  .addFlag('silent', "Hide all of ChugSplash's logs")
+  .addFlag('hide', "Hide all of ChugSplash's logs")
   .addFlag('noCompile', "Don't compile when running this task")
   .setAction(
     async (
       args: {
         deployAll: boolean
         disableChugsplash: boolean
-        silent: boolean
+        hide: boolean
         noCompile: boolean
         confirm: boolean
       },
       hre: HardhatRuntimeEnvironment,
       runSuper
     ) => {
-      const { deployAll, disableChugsplash, silent, noCompile } = args
+      const { deployAll, disableChugsplash, hide: silent, noCompile } = args
 
       if (!disableChugsplash) {
         const spinner = ora({ isSilent: silent })


### PR DESCRIPTION
The `silent` field conflicts with another Hardhat plugin in Optimism's monorepo, so I'm changing it to `hide`.