### PR TITLE
fix chugsplash manager computed address incorrect

### DIFF
--- a/packages/plugins/src/foundry/index.ts
+++ b/packages/plugins/src/foundry/index.ts
@@ -32,6 +32,7 @@ import { ethers } from 'ethers'
 import {
   ChugSplashBootloaderOneArtifact,
   ChugSplashBootloaderTwoArtifact,
+  ChugSplashManagerProxyArtifact,
 } from '@chugsplash/contracts'
 import { remove0x } from '@eth-optimism/core-utils'
 
@@ -407,6 +408,11 @@ const decodeCachedConfig = async (encodedConfigCache: string) => {
       )
 
       process.stdout.write(encodedArtifacts)
+      break
+    }
+    case 'getChugSplashManagerProxyBytecode': {
+      const bytecode = ChugSplashManagerProxyArtifact.bytecode
+      process.stdout.write(bytecode)
       break
     }
     case 'getMinimalParsedConfig': {


### PR DESCRIPTION
## Purpose
Fixes an issue where the chugsplash manager address was not properly computed in foundry. This was due to two issues: 
1. The bytecode of the proxy was fetched using `type(ChugSplashManagerProxy).creationCode` which cannot be used for computing addresses b/c the bytecode is dependent on the users compiler configuration. I've updated this to instead use FFI to fetch the exact bytecode from the artifact like we do for the rest of our create2 deployments in foundry. 
2. The constructor args were incorrectly appended to the bytecode. The constructor args need to be separately encoded before they are appended to the bytecode using encodePacked.