### PR TITLE
Random cleanup

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -3,6 +3,8 @@ import { CustomChain } from '@nomiclabs/hardhat-etherscan/dist/src/types'
 
 export const CONTRACT_SIZE_LIMIT = 24576 // bytes
 
+export const WEBSITE_URL = `https://chugsplash.io`
+
 // Etherscan constants
 export const customChains: CustomChain[] = []
 

--- a/packages/core/src/messages/index.ts
+++ b/packages/core/src/messages/index.ts
@@ -1,6 +1,6 @@
 import { BigNumber, ethers } from 'ethers'
 
-import { Integration } from '../constants'
+import { Integration, WEBSITE_URL } from '../constants'
 
 export const resolveNetworkName = async (
   provider: ethers.providers.Provider,
@@ -17,26 +17,11 @@ export const resolveNetworkName = async (
   return networkName
 }
 
-export const errorProjectNotClaimed = async (
-  provider: ethers.providers.JsonRpcProvider,
-  configPath: string,
-  integration: Integration
-) => {
-  const networkName = await resolveNetworkName(provider, integration)
-
-  if (integration === 'hardhat') {
-    throw new Error(`This project has not been claimed on ${networkName}.
-To claim the project on this network, run the following command:
-
-npx hardhat chugsplash-claim --network <network> --owner <ownerAddress> --config-path ${configPath}
-  `)
-  } else {
-    throw new Error(`This project has not been claimed on ${networkName}.
-To claim the project on this network, call the claim function from your script:
-
-chugsplash.finalizeRegistration("${configPath}");
-`)
-  }
+export const errorProjectNotClaimed = (organizationID: string) => {
+  throw new Error(
+    `The organization ID "${organizationID}" has not been claimed.\n` +
+      `Go to ${WEBSITE_URL} to claim it.`
+  )
 }
 
 export const successfulProposalMessage = async (

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -144,7 +144,7 @@ export const chugsplashProposeAbstractTask = async (
     parsedConfig.options.organizationID
   )
   if (!(await isProjectClaimed(registry, manager.address))) {
-    await errorProjectNotClaimed(provider, configPath, integration)
+    errorProjectNotClaimed(organizationID)
   }
 
   if (integration === 'hardhat') {
@@ -168,7 +168,7 @@ export const chugsplashProposeAbstractTask = async (
     deploymentState.status === DeploymentStatus.APPROVED ||
     deploymentState.status === DeploymentStatus.PROXIES_INITIATED
   ) {
-    spinner.fail(
+    throw new Error(
       `Project was already proposed and is currently being executed on ${networkName}.`
     )
   } else {
@@ -186,7 +186,7 @@ export const chugsplashProposeAbstractTask = async (
     )
 
     if (deploymentState.status === DeploymentStatus.PROPOSED) {
-      spinner.fail(
+      throw new Error(
         await alreadyProposedMessage(
           provider,
           amountToDeposit,
@@ -371,7 +371,7 @@ export const chugsplashApproveAbstractTask = async (
   const manager = getChugSplashManager(signer, organizationID)
 
   if (!(await isProjectClaimed(registry, manager.address))) {
-    await errorProjectNotClaimed(provider, configPath, integration)
+    errorProjectNotClaimed(organizationID)
   }
 
   const { configUri, bundles } = await getBundleInfo(
@@ -454,7 +454,7 @@ export const chugsplashFundAbstractTask = async (
   const signerBalance = await signer.getBalance()
 
   if (!(await isProjectClaimed(registry, manager.address))) {
-    await errorProjectNotClaimed(provider, configPath, integration)
+    errorProjectNotClaimed(organizationID)
   }
 
   const amountToDeposit = await getAmountToDeposit(
@@ -717,7 +717,7 @@ export const chugsplashCancelAbstractTask = async (
   const manager = getChugSplashManager(signer, organizationID)
 
   if (!(await isProjectClaimed(registry, manager.address))) {
-    await errorProjectNotClaimed(provider, configPath, integration)
+    errorProjectNotClaimed(organizationID)
   }
 
   const projectOwnerAddress = await manager.owner()
@@ -858,7 +858,7 @@ export const chugsplashExportProxyAbstractTask = async (
 
   // Throw an error if the project has not been claimed
   if ((await isProjectClaimed(registry, manager.address)) === false) {
-    await errorProjectNotClaimed(provider, configPath, integration)
+    errorProjectNotClaimed(organizationID)
   }
 
   const projectOwner = await manager.owner()
@@ -920,7 +920,7 @@ export const chugsplashImportProxyAbstractTask = async (
 
   // Throw an error if the project has not been claimed
   if ((await isProjectClaimed(registry, manager.address)) === false) {
-    await errorProjectNotClaimed(provider, configPath, integration)
+    errorProjectNotClaimed(organizationID)
   }
 
   spinner.succeed('Project registration detected')

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,5 +1,7 @@
 import * as path from 'path'
 import * as fs from 'fs'
+import { promisify } from 'util'
+import { exec } from 'child_process'
 
 import ora from 'ora'
 import * as semver from 'semver'
@@ -1207,3 +1209,5 @@ export const getImplAddress = (
   const implSalt = ethers.utils.keccak256(implInitCode)
   return getCreate3Address(managerAddress, implSalt)
 }
+
+export const execAsync = promisify(exec)

--- a/packages/plugins/src/cli/Propose.s.sol
+++ b/packages/plugins/src/cli/Propose.s.sol
@@ -1,18 +1,12 @@
-import { ChugSplash } from "../../foundry-contracts/ChugSplash.sol";
+import "forge-std/Script.sol";
+import "forge-std/Test.sol";
+import "../../foundry-contracts/ChugSplash.sol";
 
-import { SimpleStorage } from "../../contracts/SimpleStorage.sol";
-import { Storage } from "../../contracts/Storage.sol";
-import { ComplexConstructorArgs } from "../../contracts/ComplexConstructorArgs.sol";
-import { Stateless } from "../../contracts/Stateless.sol";
-
-contract ChugSplashScript is ChugSplash {
-    string private rpcUrl = vm.envString("CHUGSPLASH_INTERNAL_RPC_URL");
+contract ChugSplashScript is Script, Test, ChugSplash {
+    string private networkAlias = vm.envString("CHUGSPLASH_INTERNAL_NETWORK");
     string private configPath = vm.envString("CHUGSPLASH_INTERNAL_CONFIG_PATH");
-    bool private silent = vm.envBool("CHUGSPLASH_INTERNAL_SILENT");
 
     function run() public {
-        if (silent) silence();
-
-        propose(configPath, rpcUrl);
+        propose(configPath, vm.rpcUrl(networkAlias));
     }
 }

--- a/packages/plugins/src/cli/Propose.s.sol
+++ b/packages/plugins/src/cli/Propose.s.sol
@@ -1,12 +1,13 @@
-import "forge-std/Script.sol";
-import "forge-std/Test.sol";
-import "../../foundry-contracts/ChugSplash.sol";
+import { ChugSplash } from "../../foundry-contracts/ChugSplash.sol";
 
-contract ChugSplashScript is Script, Test, ChugSplash {
-    string private networkAlias = vm.envString("CHUGSPLASH_INTERNAL_NETWORK");
+contract ChugSplashScript is ChugSplash {
+    string private rpcUrl = vm.envString("CHUGSPLASH_INTERNAL_RPC_URL");
     string private configPath = vm.envString("CHUGSPLASH_INTERNAL_CONFIG_PATH");
+    bool private silent = vm.envBool("CHUGSPLASH_INTERNAL_SILENT");
 
     function run() public {
-        propose(configPath, vm.rpcUrl(networkAlias));
+        if (silent) silence();
+
+        propose(configPath, rpcUrl);
     }
 }

--- a/packages/plugins/src/cli/Propose.s.sol
+++ b/packages/plugins/src/cli/Propose.s.sol
@@ -1,12 +1,18 @@
-import "forge-std/Script.sol";
-import "forge-std/Test.sol";
-import "../../foundry-contracts/ChugSplash.sol";
+import { ChugSplash } from "../../foundry-contracts/ChugSplash.sol";
 
-contract ChugSplashScript is Script, Test, ChugSplash {
-    string private networkAlias = vm.envString("CHUGSPLASH_INTERNAL_NETWORK");
+import { SimpleStorage } from "../../contracts/SimpleStorage.sol";
+import { Storage } from "../../contracts/Storage.sol";
+import { ComplexConstructorArgs } from "../../contracts/ComplexConstructorArgs.sol";
+import { Stateless } from "../../contracts/Stateless.sol";
+
+contract ChugSplashScript is ChugSplash {
+    string private rpcUrl = vm.envString("CHUGSPLASH_INTERNAL_RPC_URL");
     string private configPath = vm.envString("CHUGSPLASH_INTERNAL_CONFIG_PATH");
+    bool private silent = vm.envBool("CHUGSPLASH_INTERNAL_SILENT");
 
     function run() public {
-        propose(configPath, vm.rpcUrl(networkAlias));
+        if (silent) silence();
+
+        propose(configPath, rpcUrl);
     }
 }

--- a/packages/plugins/src/cli/index.ts
+++ b/packages/plugins/src/cli/index.ts
@@ -15,7 +15,6 @@ dotenv.config()
 
 yargs(hideBin(process.argv))
   .scriptName('chugsplash')
-  .usage('Usage: npx <cmd> [args]')
   .command(
     'propose',
     'Propose a deployment',

--- a/packages/plugins/src/cli/index.ts
+++ b/packages/plugins/src/cli/index.ts
@@ -1,51 +1,136 @@
 #!/usr/bin/env node
-import { execSync } from 'child_process'
+import { resolve } from 'path'
 
+import * as dotenv from 'dotenv'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import ora from 'ora'
+import { execAsync } from '@chugsplash/core/dist/utils'
 
 import { writeSampleProjectFiles } from '../sample-project'
+import { inferSolcVersion } from '../foundry/utils'
+
+// Load environment variables from .env
+dotenv.config()
 
 yargs(hideBin(process.argv))
-  .option('config-path', {
-    alias: 'c',
-    describe: 'Path to config file',
-    type: 'string',
-  })
-  .option('network', {
-    alias: 'n',
-    describe:
-      'Network to deploy to, must be an alias in your foundry.toml file',
-    type: 'string',
-  })
+  .scriptName('chugsplash')
+  .usage('Usage: npx <cmd> [args]')
   .command(
     'propose',
-    'Propose a new deployment',
-    (y) => y.demandOption('config-path', true).demandOption('network', true),
+    'Propose a deployment',
+    (y) =>
+      y
+        .usage(
+          'Usage: npx chugsplash propose --config-path <path> --rpc-url <url> [--silent]'
+        )
+        .option('config-path', {
+          alias: 'c',
+          describe: 'Path to the ChugSplash config file to propose',
+          type: 'string',
+        })
+        .option('rpc-url', {
+          alias: 'r',
+          describe: 'RPC URL for the network to propose on',
+          type: 'string',
+        })
+        .option('silent', {
+          describe: `Hide ChugSplash's output`,
+          boolean: true,
+          alias: 's',
+        })
+        .hide('version'),
     async (argv) => {
-      const configPath = argv.configPath
-      const network = argv.network
-      process.env['CHUGSPLASH_INTERNAL_NETWORK'] = network
+      const { configPath, rpcUrl } = argv
+      const silent = argv.silent ?? false
+      if (!configPath) {
+        console.error('Must specify a path to a ChugSplash config file.')
+        process.exit(1)
+      }
+      if (!rpcUrl) {
+        console.error('Must specify an RPC URL.')
+        process.exit(1)
+      }
+
+      const privateKey = process.env.PRIVATE_KEY
+      if (!privateKey) {
+        console.error(`Must specify a "PRIVATE_KEY" in your .env file.`)
+        process.exit(1)
+      }
+
+      process.env['CHUGSPLASH_INTERNAL_RPC_URL'] = rpcUrl
       process.env['CHUGSPLASH_INTERNAL_CONFIG_PATH'] = configPath
-      await execSync('forge script src/cli/Propose.s.sol', {
-        stdio: 'inherit',
-      })
+      process.env['CHUGSPLASH_INTERNAL_SILENT'] = silent.toString()
+
+      const spinner = ora()
+      spinner.start('Proposing...')
+      try {
+        await execAsync(`forge script src/cli/Propose.s.sol`)
+      } catch ({ stderr }) {
+        spinner.fail('Proposal failed.')
+        // Strip \n from the end of the error message, if it exists
+        const prettyError = stderr.endsWith('\n')
+          ? stderr.substring(0, stderr.length - 1)
+          : stderr
+
+        console.error(prettyError)
+        process.exit(1)
+      }
+      spinner.succeed('Successfully proposed!')
     }
   )
-  .command('init', 'Initialize a new project', async () => {
-    const spinner = ora()
+  .command(
+    'init',
+    'Initialize a sample project',
+    (y) =>
+      y
+        .usage('Usage: npx chugsplash init --js|--ts')
+        .option('js', {
+          describe: 'Create a JavaScript ChugSplash config file',
+          boolean: true,
+        })
+        .option('ts', {
+          describe: 'Create a TypeScript ChugSplash config file',
+          boolean: true,
+        })
+        .hide('version'),
+    async (argv) => {
+      const { ts, js } = argv
+      if (ts && js) {
+        console.error('Cannot specify both --ts and --js. Please choose one.')
+        process.exit(1)
+      } else if (!ts && !js) {
+        console.error(
+          'Must specify either --ts (TypeScript) or --js (JavaScript).'
+        )
+        process.exit(1)
+      }
 
-    await writeSampleProjectFiles(
-      './chugsplash',
-      './src',
-      './test',
-      './script',
-      false,
-      '0.8.17',
-      'foundry'
-    )
-    spinner.succeed('Initialized ChugSplash project.')
-  })
-  .demandCommand(1, 'You need at least one command')
+      const isTypeScriptProject = ts ? true : false
+
+      const spinner = ora()
+
+      const forgeConfigOutput = await execAsync('forge config --json')
+      const forgeConfig = JSON.parse(forgeConfigOutput.stdout)
+      const { src, test, script, solc } = forgeConfig
+
+      const solcVersion = solc ?? (await inferSolcVersion())
+
+      writeSampleProjectFiles(
+        resolve('chugsplash'),
+        src,
+        test,
+        isTypeScriptProject,
+        solcVersion,
+        'foundry',
+        script
+      )
+      spinner.succeed('Initialized ChugSplash project.')
+    }
+  )
+  .showHelpOnFail(true)
+  .demandCommand(
+    1,
+    'To get help for a specific task run: npx chugsplash [task] --help'
+  )
   .parse()

--- a/packages/plugins/src/cli/index.ts
+++ b/packages/plugins/src/cli/index.ts
@@ -65,6 +65,11 @@ yargs(hideBin(process.argv))
       const spinner = ora()
       spinner.start('Proposing...')
       try {
+        // Although it's not strictly necessary to propose via a Forge script, we do it anyways
+        // because it's a convenient way to ensure that the latest versions of the contracts are
+        // compiled. It's also convenient because it invokes `ts-node`, which allows us to support
+        // TypeScript configs. This can't be done by calling the TypeScript propose function
+        // directly because calling `npx chugsplash` uses Node, not `ts-node`.
         await execAsync(`forge script src/cli/Propose.s.sol`)
       } catch ({ stderr }) {
         spinner.fail('Proposal failed.')

--- a/packages/plugins/src/foundry/get-bundle-info.ts
+++ b/packages/plugins/src/foundry/get-bundle-info.ts
@@ -6,100 +6,22 @@ import { FailureAction } from '@chugsplash/core/dist/types'
 import { getBundleInfo } from '@chugsplash/core/dist/tasks'
 import { defaultAbiCoder, hexConcat } from 'ethers/lib/utils'
 import { remove0x } from '@eth-optimism/core-utils/dist/common/hex-strings'
-import { ConfigArtifacts } from '@chugsplash/core/dist/config/types'
-import { getEstDeployContractCost } from '@chugsplash/core/dist/utils'
-import { BigNumber } from 'ethers/lib/ethers'
 
 import { createChugSplashRuntime } from '../cre'
 import { getPaths } from './paths'
 import { decodeCachedConfig } from './structs'
 import { makeGetConfigArtifacts } from './utils'
+import {
+  getDeployContractCosts,
+  getEncodedFailure,
+  getPrettyWarnings,
+  validationStderrWrite,
+} from './logs'
 
 const args = process.argv.slice(2)
 const encodedConfigCache = args[0]
 const userConfigStr = args[1]
 const userConfig = JSON.parse(userConfigStr)
-
-type DeployContractCost = {
-  referenceName: string
-  cost: BigNumber
-}
-
-// These variables are used to capture any errors or warnings that occur during the ChugSplash
-// config validation process.
-let validationWarnings: string = ''
-let validationErrors: string = ''
-// This function overrides the default 'stderr.write' function to capture any errors or warnings
-// that occur during the validation process.
-const validationStderrWrite = (message: string) => {
-  if (message.startsWith('\nWarning: ')) {
-    validationWarnings += message.replace('\n', '')
-  } else if (message.startsWith('\nError: ')) {
-    // We remove '\nError: ' because Foundry already displays the word "Error" when an error occurs.
-    validationErrors += message.replace('\nError: ', '')
-  } else {
-    validationErrors += message
-  }
-  return true
-}
-
-const getEncodedFailure = (err: Error): string => {
-  // Trim a trailing '\n' character from the end of 'warnings' if it exists.
-  const prettyWarnings = getPrettyWarnings()
-
-  let prettyError: string
-  if (err.name === 'ValidationError') {
-    // We return the error messages and warnings.
-
-    // Removes unnecessary '\n' characters from the end of 'errors'
-    prettyError = validationErrors.endsWith('\n\n')
-      ? validationErrors.substring(0, validationErrors.length - 2)
-      : validationErrors
-  } else {
-    // A non-parsing error occurred. We return the error message and stack trace.
-    prettyError = `${err.name}: ${err.message}\n\n${err.stack}`
-  }
-
-  const encodedErrorsAndWarnings = defaultAbiCoder.encode(
-    ['string', 'string'],
-    [prettyError, prettyWarnings]
-  )
-
-  const encodedFailure = hexConcat([
-    encodedErrorsAndWarnings,
-    defaultAbiCoder.encode(['bool'], [false]), // false = failure
-  ])
-
-  return encodedFailure
-}
-
-// Removes a '\n' character from the end of 'warnings' if it exists.
-const getPrettyWarnings = (): string => {
-  return validationWarnings.endsWith('\n\n')
-    ? validationWarnings.substring(0, validationWarnings.length - 1)
-    : validationWarnings
-}
-
-const getDeployContractCosts = (
-  configArtifacts: ConfigArtifacts
-): DeployContractCost[] => {
-  const deployContractCosts: DeployContractCost[] = []
-  for (const [referenceName, { artifact, buildInfo }] of Object.entries(
-    configArtifacts
-  )) {
-    const { sourceName, contractName } = artifact
-
-    const deployContractCost = getEstDeployContractCost(
-      buildInfo.output.contracts[sourceName][contractName].evm.gasEstimates
-    )
-
-    deployContractCosts.push({
-      referenceName,
-      cost: deployContractCost,
-    })
-  }
-  return deployContractCosts
-}
 
 ;(async () => {
   process.stderr.write = validationStderrWrite

--- a/packages/plugins/src/foundry/index.ts
+++ b/packages/plugins/src/foundry/index.ts
@@ -41,7 +41,6 @@ const command = args[0]
         const configPath = args[1]
         const rpcUrl = args[2]
         const privateKey = args[3]
-        const silent = args[4] === 'true'
 
         const { artifactFolder, buildInfoFolder, canonicalConfigFolder } =
           await getPaths()
@@ -52,7 +51,7 @@ const command = args[0]
           true,
           canonicalConfigFolder,
           undefined,
-          silent,
+          true,
           process.stderr
         )
 

--- a/packages/plugins/src/foundry/index.ts
+++ b/packages/plugins/src/foundry/index.ts
@@ -7,7 +7,6 @@ import {
   ProposalRoute,
   getChugSplashRegistryReadOnly,
   getPreviousConfigUri,
-  isLocalNetwork,
   postDeploymentActions,
   CanonicalChugSplashConfig,
   getChugSplashManagerReadOnly,
@@ -16,12 +15,19 @@ import {
   initializeChugSplash,
   bytecodeContainsEIP1967Interface,
   bytecodeContainsUUPSInterface,
+  FailureAction,
 } from '@chugsplash/core'
 import { Contract, ethers } from 'ethers'
+import { defaultAbiCoder, hexConcat } from 'ethers/lib/utils'
 
 import { getPaths } from './paths'
 import { makeGetConfigArtifacts } from './utils'
 import { createChugSplashRuntime } from '../cre'
+import {
+  getEncodedFailure,
+  getPrettyWarnings,
+  validationStderrWrite,
+} from './logs'
 
 const args = process.argv.slice(2)
 const command = args[0]
@@ -29,49 +35,65 @@ const command = args[0]
 ;(async () => {
   switch (command) {
     case 'propose': {
-      const configPath = args[1]
-      const rpcUrl = args[2]
-      const privateKey = args[3]
-      const silent = args[4] === 'true'
+      process.stderr.write = validationStderrWrite
 
-      const { artifactFolder, buildInfoFolder, canonicalConfigFolder } =
-        await getPaths()
+      try {
+        const configPath = args[1]
+        const rpcUrl = args[2]
+        const privateKey = args[3]
+        const silent = args[4] === 'true'
 
-      const provider = new ethers.providers.JsonRpcProvider(rpcUrl)
-      const remoteExecution = !(await isLocalNetwork(provider))
-      const cre = await createChugSplashRuntime(
-        remoteExecution,
-        true,
-        canonicalConfigFolder,
-        undefined,
-        silent,
-        process.stdout
-      )
+        const { artifactFolder, buildInfoFolder, canonicalConfigFolder } =
+          await getPaths()
 
-      const { parsedConfig, configArtifacts, configCache } =
-        await readValidatedChugSplashConfig(
-          configPath,
-          provider,
-          cre,
-          makeGetConfigArtifacts(artifactFolder, buildInfoFolder)
+        const provider = new ethers.providers.JsonRpcProvider(rpcUrl)
+        const cre = await createChugSplashRuntime(
+          true,
+          true,
+          canonicalConfigFolder,
+          undefined,
+          silent,
+          process.stderr
         )
-      const wallet = new ethers.Wallet(privateKey, provider)
 
-      if (!silent) {
-        console.log('-- ChugSplash Propose --')
+        const { parsedConfig, configArtifacts, configCache } =
+          await readValidatedChugSplashConfig(
+            configPath,
+            provider,
+            cre,
+            makeGetConfigArtifacts(artifactFolder, buildInfoFolder),
+            FailureAction.THROW
+          )
+        const wallet = new ethers.Wallet(privateKey, provider)
+
+        await chugsplashProposeAbstractTask(
+          provider,
+          wallet,
+          parsedConfig,
+          configPath,
+          '',
+          'foundry',
+          configArtifacts,
+          ProposalRoute.REMOTE_EXECUTION,
+          cre,
+          configCache
+        )
+
+        const encodedProjectNameAndWarnings = defaultAbiCoder.encode(
+          ['string', 'string'],
+          [parsedConfig.options.projectName, getPrettyWarnings()]
+        )
+
+        const encodedSuccess = hexConcat([
+          encodedProjectNameAndWarnings,
+          defaultAbiCoder.encode(['bool'], [true]), // true = success
+        ])
+
+        process.stdout.write(encodedSuccess)
+      } catch (err) {
+        const encodedFailure = getEncodedFailure(err)
+        process.stdout.write(encodedFailure)
       }
-      await chugsplashProposeAbstractTask(
-        provider,
-        wallet,
-        parsedConfig,
-        configPath,
-        '',
-        'foundry',
-        configArtifacts,
-        ProposalRoute.REMOTE_EXECUTION,
-        cre,
-        configCache
-      )
       break
     }
     case 'getPreviousConfigUri': {

--- a/packages/plugins/src/foundry/logs.ts
+++ b/packages/plugins/src/foundry/logs.ts
@@ -1,0 +1,92 @@
+// These variables are used to capture any errors or warnings that occur during the ChugSplash
+
+import { ConfigArtifacts } from '@chugsplash/core/dist/config/types'
+import { getEstDeployContractCost } from '@chugsplash/core/dist/utils'
+import { BigNumber } from 'ethers/lib/ethers'
+import { defaultAbiCoder, hexConcat } from 'ethers/lib/utils'
+
+export type DeployContractCost = {
+  referenceName: string
+  cost: BigNumber
+}
+
+// config validation process.
+let validationWarnings: string = ''
+let validationErrors: string = ''
+// This function overrides the default 'stderr.write' function to capture any errors or warnings
+// that occur during the validation process.
+export const validationStderrWrite = (message: string) => {
+  if (message.startsWith('\nWarning: ')) {
+    validationWarnings += message.replace('\n', '')
+  } else if (message.startsWith('\nError: ')) {
+    // We remove '\nError: ' because Foundry already displays the word "Error" when an error occurs.
+    validationErrors += message.replace('\nError: ', '')
+  } else {
+    validationErrors += message
+  }
+  return true
+}
+
+export const getEncodedFailure = (err: Error): string => {
+  // Trim a trailing '\n' character from the end of 'warnings' if it exists.
+  const prettyWarnings = getPrettyWarnings()
+
+  let prettyError: string
+  if (err.name === 'ValidationError') {
+    // We return the error messages and warnings.
+
+    // Removes unnecessary '\n' characters from the end of 'errors'
+    prettyError = validationErrors.endsWith('\n\n')
+      ? validationErrors.substring(0, validationErrors.length - 2)
+      : validationErrors
+  } else {
+    // A non-parsing error occurred. We return the full stack trace if it exists. Otherwise we
+    // return the error name and message.
+    const errorMessage = err.stack ?? `${err.name}: ${err.message}`
+    // Strip 'Error: ' from the beginning of the error message if it exists, since Foundry already
+    // displays the word "Error" when an error occurs.
+    prettyError = errorMessage.startsWith('Error: ')
+      ? errorMessage.substring(7)
+      : errorMessage
+  }
+
+  const encodedErrorsAndWarnings = defaultAbiCoder.encode(
+    ['string', 'string'],
+    [prettyError, prettyWarnings]
+  )
+
+  const encodedFailure = hexConcat([
+    encodedErrorsAndWarnings,
+    defaultAbiCoder.encode(['bool'], [false]), // false = failure
+  ])
+
+  return encodedFailure
+}
+
+// Removes a '\n' character from the end of 'warnings' if it exists.
+export const getPrettyWarnings = (): string => {
+  return validationWarnings.endsWith('\n\n')
+    ? validationWarnings.substring(0, validationWarnings.length - 1)
+    : validationWarnings
+}
+
+export const getDeployContractCosts = (
+  configArtifacts: ConfigArtifacts
+): DeployContractCost[] => {
+  const deployContractCosts: DeployContractCost[] = []
+  for (const [referenceName, { artifact, buildInfo }] of Object.entries(
+    configArtifacts
+  )) {
+    const { sourceName, contractName } = artifact
+
+    const deployContractCost = getEstDeployContractCost(
+      buildInfo.output.contracts[sourceName][contractName].evm.gasEstimates
+    )
+
+    deployContractCosts.push({
+      referenceName,
+      cost: deployContractCost,
+    })
+  }
+  return deployContractCosts
+}

--- a/packages/plugins/src/foundry/utils/index.ts
+++ b/packages/plugins/src/foundry/utils/index.ts
@@ -9,12 +9,14 @@ import {
 import {
   parseFoundryArtifact,
   validateBuildInfo,
+  execAsync,
 } from '@chugsplash/core/dist/utils'
 import {
   ConfigArtifacts,
   GetConfigArtifacts,
   UserContractConfigs,
 } from '@chugsplash/core/dist/config/types'
+import { parse } from 'semver'
 
 const readFileAsync = promisify(fs.readFile)
 const existsAsync = promisify(fs.exists)
@@ -117,5 +119,22 @@ export const makeGetConfigArtifacts = (
       }
     }
     return configArtifacts
+  }
+}
+
+/**
+ * Attempts to infer the default solc version given by `solc --version`. If this fails, it will
+ * return the default solc version used by Foundry's "Getting Started" guide, which is 0.8.20.
+ */
+export const inferSolcVersion = async (): Promise<string> => {
+  // This is the default solc version used by Foundry's "Getting Started" guide.
+  const defaultSolcVersion = '0.8.20'
+  try {
+    const solcVersionOutput = await execAsync('solc --version')
+    const solcVersionRaw = solcVersionOutput.stdout.split('Version: ')[1]
+    const parsed = parse(solcVersionRaw)
+    return parsed ? parsed.toString() : defaultSolcVersion
+  } catch (err) {
+    return defaultSolcVersion
   }
 }

--- a/packages/plugins/src/sample-project/index.ts
+++ b/packages/plugins/src/sample-project/index.ts
@@ -21,14 +21,14 @@ import {
   sampleTestFileTypeScript,
 } from './sample-tests'
 
-export const writeSampleProjectFiles = async (
+export const writeSampleProjectFiles = (
   chugsplashPath: string,
   sourcePath: string,
   testPath: string,
-  scriptPath: string,
   isTypeScriptProject: boolean,
   solcVersion: string,
-  integration: Integration
+  integration: Integration,
+  scriptPath?: string
 ) => {
   // Create the ChugSplash folder if it doesn't exist
   if (!fs.existsSync(chugsplashPath)) {
@@ -42,11 +42,6 @@ export const writeSampleProjectFiles = async (
 
   // Create a folder for test files if it doesn't exist
   if (!fs.existsSync(testPath)) {
-    fs.mkdirSync(testPath)
-  }
-
-  // Create a folder for script files if it doesn't exist
-  if (!fs.existsSync(scriptPath)) {
     fs.mkdirSync(testPath)
   }
 
@@ -91,7 +86,18 @@ export const writeSampleProjectFiles = async (
           : sampleTestFileJavaScript
       )
     }
-  } else {
+  } else if (integration === 'foundry') {
+    if (!scriptPath) {
+      throw new Error(
+        'Script path is required for foundry integration. Should never happen.'
+      )
+    }
+
+    // Create a folder for Forge script files if it doesn't exist
+    if (!fs.existsSync(scriptPath)) {
+      fs.mkdirSync(scriptPath)
+    }
+
     // Check if the sample test file exists.
     const testFileName = 'HelloChugSplash.t.sol'
     const testFilePath = path.join(testPath, testFileName)

--- a/packages/plugins/src/scripts/ChugSplash.s.sol
+++ b/packages/plugins/src/scripts/ChugSplash.s.sol
@@ -2,15 +2,15 @@
 pragma solidity ^0.8.15;
 
 import { ChugSplash } from "../../foundry-contracts/ChugSplash.sol";
-// import { SimpleStorage } from "../../contracts/SimpleStorage.sol";
+import { SimpleStorage } from "../../contracts/SimpleStorage.sol";
 import { Storage } from "../../contracts/Storage.sol";
 import { ComplexConstructorArgs } from "../../contracts/ComplexConstructorArgs.sol";
 import { Stateless } from "../../contracts/Stateless.sol";
 
 contract ChugSplashScript is ChugSplash {
     function run() public {
-        // ensureChugSplashInitialized(vm.rpcUrl("anvil"));
+        ensureChugSplashInitialized(vm.rpcUrl("anvil"));
 
-        deploy("./chugsplash/Storage.consfig.ts", vm.rpcUrl("anvil"));
+        deploy("./chugsplash/Storage.config.ts", vm.rpcUrl("anvil"));
     }
 }

--- a/packages/plugins/src/scripts/ChugSplash.s.sol
+++ b/packages/plugins/src/scripts/ChugSplash.s.sol
@@ -2,15 +2,15 @@
 pragma solidity ^0.8.15;
 
 import { ChugSplash } from "../../foundry-contracts/ChugSplash.sol";
-import { SimpleStorage } from "../../contracts/SimpleStorage.sol";
+// import { SimpleStorage } from "../../contracts/SimpleStorage.sol";
 import { Storage } from "../../contracts/Storage.sol";
 import { ComplexConstructorArgs } from "../../contracts/ComplexConstructorArgs.sol";
 import { Stateless } from "../../contracts/Stateless.sol";
 
 contract ChugSplashScript is ChugSplash {
     function run() public {
-        ensureChugSplashInitialized(vm.rpcUrl("anvil"));
+        // ensureChugSplashInitialized(vm.rpcUrl("anvil"));
 
-        deploy("./chugsplash/Storage.config.ts", vm.rpcUrl("anvil"));
+        deploy("./chugsplash/Storage.consfig.ts", vm.rpcUrl("anvil"));
     }
 }


### PR DESCRIPTION
This PR:
* Updates the `propose` function in Solidity to support TypeScript configs as well as clean error messages, which are implemented the same way as `getBundleInfo`.
* Various improvements to: `npx chugsplash init`
  * Retrieves the user's contract, test, and script file names via `execAsync(forge config --json)`.
  * Supports TypeScript and JavaScript ChugSplash configs
  * Improves the `chugsplash init --help` flag
* Improvements to `npx chugsplash propose`
  * Uses an `--rpc-url` flag instead of `--network` since this is what `forge script` does
  * Displays helpful error messages to the user
  * Improves the `--help` flag
* Removes the `claim` and `listProjects` from the Hardhat CLI tasks