### PR TITLE
Default unsafeAllow.flexibleConstructor to false

### DIFF
--- a/packages/core/src/config/parse.ts
+++ b/packages/core/src/config/parse.ts
@@ -2208,6 +2208,23 @@ const constructParsedConfig = (
   return parsedConfig
 }
 
+export const setDefaultContractOptions = (
+  userConfig: UserChugSplashConfig
+): UserChugSplashConfig => {
+  for (const contractConfig of Object.values(userConfig.contracts)) {
+    if (contractConfig.unsafeAllow) {
+      contractConfig.unsafeAllow.flexibleConstructor =
+        contractConfig.unsafeAllow.flexibleConstructor ?? true
+    } else {
+      contractConfig.unsafeAllow = {
+        flexibleConstructor: true,
+      }
+    }
+  }
+
+  return userConfig
+}
+
 /**
  * Parses a ChugSplash config file from the config file given by the user.
  *
@@ -2227,6 +2244,8 @@ export const getUnvalidatedParsedConfig = (
   // Validate top level config and contract options
   assertValidUserConfigFields(userConfig, cre, failureAction)
 
+  const configWithDefaultOptions = setDefaultContractOptions(userConfig)
+
   // Parse and validate contract constructor args
   // During this function, we also resolve all contract references throughout the entire config b/c constructor args may impact contract addresses
   // We also cache the parsed constructor args so we don't have to re-read them later
@@ -2235,7 +2254,7 @@ export const getUnvalidatedParsedConfig = (
     cachedConstructorArgs,
     contractReferences,
   } = assertValidConstructorArgs(
-    userConfig,
+    configWithDefaultOptions,
     configArtifacts,
     cre,
     failureAction

--- a/packages/executor/chugsplash/ExecutorTest.config.ts
+++ b/packages/executor/chugsplash/ExecutorTest.config.ts
@@ -19,7 +19,6 @@ const config: UserChugSplashConfig = {
     ExecutorNonProxyTest: {
       contract: 'ExecutorNonProxyTest',
       kind: 'no-proxy',
-      unsafeAllow: { flexibleConstructor: true },
       constructorArgs: {
         _val: 1,
       },

--- a/packages/plugins/chugsplash/VariableValidation.config.ts
+++ b/packages/plugins/chugsplash/VariableValidation.config.ts
@@ -80,12 +80,10 @@ const config: UserChugSplashConfig = {
     Reverter1: {
       contract: 'Reverter',
       kind: 'no-proxy',
-      unsafeAllow: { flexibleConstructor: true },
     },
     Reverter2: {
       contract: 'Reverter',
       kind: 'no-proxy',
-      unsafeAllow: { flexibleConstructor: true },
     },
   },
 }


### PR DESCRIPTION
## Purpose
Sets the value of `unsafeAllow.flexibleConstructor` to false. This is a simple way to do it, for now, later we can come back and we'll have an easy spot to add in more complex logic for determining the value based on the type of contract or some other criteria. 