### PR TITLE
fix(pg): Fix issue where reading registry code fails on live network during proposal

### DIFF
--- a/.changeset/itchy-kings-brush.md
+++ b/.changeset/itchy-kings-brush.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/plugins': patch
+---
+
+Fix issue where reading registry code fails on live network during proposal

--- a/packages/plugins/src/cli/index.ts
+++ b/packages/plugins/src/cli/index.ts
@@ -87,7 +87,9 @@ yargs(hideBin(process.argv))
         // compiled. It's also convenient because it invokes `ts-node`, which allows us to support
         // TypeScript configs. This can't be done by calling the TypeScript propose function
         // directly because calling `npx chugsplash` uses Node, not `ts-node`.
-        await execAsync(`forge script ${proposeContractPath}`)
+        await execAsync(
+          `forge script ${proposeContractPath} --rpc-url ${network}`
+        )
       } catch ({ stderr }) {
         spinner.fail('Proposal failed.')
         // Strip \n from the end of the error message, if it exists


### PR DESCRIPTION
## Purpose
Fixes an issue where we fail to properly read the registry code when proposing against a live network.