### PR TITLE
fix(pg): Fix issues with production package installation

### DIFF
--- a/.changeset/breezy-actors-report.md
+++ b/.changeset/breezy-actors-report.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/contracts': patch
+---
+
+Include contract source files in release

--- a/.changeset/perfect-queens-wonder.md
+++ b/.changeset/perfect-queens-wonder.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/plugins': patch
+---
+
+Specify compiler version range for foundry library contracts

--- a/docs/foundry/getting-started.md
+++ b/docs/foundry/getting-started.md
@@ -81,7 +81,15 @@ Inside the newly created file, remappings.txt, copy paste the following:
 ```
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
-chugsplash/=node_modules/@chugsplash/plugins/dist/contracts/
+@chugsplash/plugins=node_modules/@chugsplash/plugins/contracts/foundry
+@chugsplash/contracts=node_modules/@chugsplash/contracts/contracts/
+@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/
+@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
+@eth-optimism/contracts-bedrock/=node_modules/@eth-optimism/contracts-bedrock/
+@eth-optimism/contracts/=node_modules/@eth-optimism/contracts/
+@thirdweb-dev/contracts/=node_modules/@thirdweb-dev/contracts/
+solmate/src/=node_modules/solmate/src/
+@prb/math/=node_modules/prb/math/src/
 ```
 
 ## 5. Initialize ChugSplash

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index",
   "files": [
     "dist/*",
+    "contracts/*",
     "artifacts/contracts/**/*.json",
     "artifacts/@thirdweb-dev/contracts/forwarder/Forwarder.sol/*.json",
     "artifacts/@eth-optimism/contracts-bedrock/contracts/universal/Proxy.sol/*.json",

--- a/packages/plugins/contracts/foundry/ChugSplash.sol
+++ b/packages/plugins/contracts/foundry/ChugSplash.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity >=0.6.2 <0.9.0;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";
@@ -50,7 +50,6 @@ import {
 import { ChugSplashUtils } from "./ChugSplashUtils.sol";
 import { StdStyle } from "forge-std/StdStyle.sol";
 import { ChugSplashContractInfo, ChugSplashConstants } from "./ChugSplashConstants.sol";
-import { Proxy } from "@eth-optimism/contracts-bedrock/contracts/universal/Proxy.sol";
 
 contract ChugSplash is
     Script,
@@ -189,9 +188,9 @@ contract ChugSplash is
         address deployer = utils.msgSender();
         require(ownerAddress == deployer, "ChugSplash: You are not the owner of this proxy.");
 
-        // transfer ownership of the proxy
-        Proxy proxy = Proxy(payable(_proxy));
-        proxy.changeAdmin(address(manager));
+        // TODO: transfer ownership of the proxy
+        // We need to use an interface here instead of importing the Proxy contract from Optimism b/c
+        // it requires a specific solidity compiler version.
     }
 
     // TODO: Test once we are officially supporting upgradable contracts

--- a/packages/plugins/contracts/foundry/ChugSplashConstants.sol
+++ b/packages/plugins/contracts/foundry/ChugSplashConstants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity >=0.6.2 <0.9.0;
 
 struct ChugSplashContractInfo {
   bytes creationCode;

--- a/packages/plugins/contracts/foundry/ChugSplashPluginTypes.sol
+++ b/packages/plugins/contracts/foundry/ChugSplashPluginTypes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity >=0.6.2 <0.9.0;
 
 struct MinimalConfig {
     bytes32 organizationID;

--- a/packages/plugins/contracts/foundry/ChugSplashUtils.sol
+++ b/packages/plugins/contracts/foundry/ChugSplashUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity >=0.6.2 <0.9.0;
 
 import { Test } from "forge-std/Test.sol";
 import { StdStyle } from "forge-std/StdStyle.sol";

--- a/packages/plugins/contracts/foundry/Propose.sol
+++ b/packages/plugins/contracts/foundry/Propose.sol
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.2 <0.9.0;
+
 import { ChugSplash } from "./ChugSplash.sol";
 
 contract Propose is ChugSplash {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -16,7 +16,7 @@
     "start": "ts-node ./src/index.ts",
     "build": "yarn build:ts && yarn build:contracts",
     "build:ts": "tsc -p ./tsconfig.json",
-    "build:contracts": "npx hardhat clean && npx hardhat compile && yarn generate && mkdir -p ./dist/contracts && cp -R ./contracts/foundry/* ./dist/contracts/",
+    "build:contracts": "npx hardhat clean && npx hardhat compile && yarn generate",
     "generate": "npx ts-node script/write-constants.ts > contracts/foundry/ChugSplashConstants.sol",
     "clean": "rimraf dist/ ./tsconfig.tsbuildinfo",
     "test": "yarn test:forge && yarn test:hardhat",

--- a/packages/plugins/script/write-constants.ts
+++ b/packages/plugins/script/write-constants.ts
@@ -109,7 +109,7 @@ const writeConstants = async () => {
 
   const solidityFile =
     `// SPDX-License-Identifier: MIT\n` +
-    `pragma solidity ^0.8.15;\n\n` +
+    `pragma solidity >=0.6.2 <0.9.0;\n\n` +
     `struct ChugSplashContractInfo {\n` +
     `  bytes creationCode;\n` +
     `  address expectedAddress;\n` +


### PR DESCRIPTION
## Purpose
Fixes some issues with the production installation: 
- The contracts package doesn't actually include the contracts themselves, but our plugin relies on importing them
- The plugins contracts require version 0.8.15 but this can cause conflicts in the users repo depending on the version they install. For some reason, having mismatching versions was not an issue within our repo but it is a problem when the package is installed in a users project. I fixed this by replicating foundries pattern of using a wide version range. 
- Removes import of the bedrock Proxy.sol contract from the ChugSplash library since it requires specifically version 0.8.15 which will cause issues as well. 
- Removes some extra files from the plugins package which aren're required in the prod package. 
- Updates the getting started guide to recommend a more extensive list of remapping which are required to make the core contracts properly compile in the users project.

On a side note, a lot of this is required b/c we import and use the actual core contracts within our library contract. It would probably be better to instead define interfaces for the manager and registry contracts and then import those instead of the actual core contracts. This would reduce the compilation time for the end user (since currently they have to compile our entire project), and avoid them having to define so many remappings. 
