### PR TITLE
fix(pg): Detect ambiguous contract names in configs when using foundry

### DIFF
--- a/.changeset/tough-spiders-roll.md
+++ b/.changeset/tough-spiders-roll.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/plugins': patch
+---
+
+Detect ambiguous contract names in foundry


### PR DESCRIPTION
## Purpose
Fixes an edge case where there can be some ambiguity in which contract artifact is being used if there are multiple contracts in different files with the same name. We handle this by tracking which contract names appear in different source files, and then throwing an error if the user references a contract that appears in multiple files without using the fully qualified name. 